### PR TITLE
Fix InputConnection local-window coordinate handling

### DIFF
--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -10,6 +10,12 @@ import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
 
+internal fun relativeCursorKeyCode(delta: Int): Int? = when (delta) {
+    -1 -> KeyEvent.KEYCODE_DPAD_LEFT
+    1 -> KeyEvent.KEYCODE_DPAD_RIGHT
+    else -> null
+}
+
 /**
  * Single funnel for all editor side effects. Password fields are never logged,
  * uploaded or added to history; direct typing is still forwarded to the editor.
@@ -157,9 +163,8 @@ class InputConnectionGateway(
             }
             is SelectionSnapshot.Relative -> {
                 if (start != end) return
-                when (start - selection.cursor) {
-                    -1 -> sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_LEFT)
-                    1 -> sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_RIGHT)
+                relativeCursorKeyCode(start - selection.cursor)?.let { keyCode ->
+                    sendKeyDownUp(ic, keyCode)
                 }
             }
             null -> Unit

--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
+import android.view.KeyEvent
 import android.view.inputmethod.ExtractedText
 import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
@@ -122,27 +123,74 @@ class InputConnectionGateway(
 
     fun sendKeyDownUp(keyCode: Int) {
         val ic = connection() ?: return
-        ic.sendKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, keyCode))
-        ic.sendKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_UP, keyCode))
+        sendKeyDownUp(ic, keyCode)
     }
 
+    /**
+     * Prefer the editor's own select-all implementation. A bounded extracted
+     * window must never be mistaken for the complete document.
+     */
     fun selectAll() {
-        val info = surroundingText() ?: return
-        connection()?.setSelection(0, info.text.length)
+        if (isPassword()) return
+        val ic = connection() ?: return
+        if (runCatching { ic.performContextMenuAction(android.R.id.selectAll) }.getOrDefault(false)) return
+        val window = extractedWindow(ic) ?: return
+        if (window.windowStart == 0) {
+            ic.setSelection(0, window.text.length)
+        }
     }
 
+    /** Set an absolute editor selection; do not clamp it to a local extracted window. */
     fun selectStartEnd(start: Int, end: Int) {
-        val info = surroundingText() ?: return
-        val safeStart = start.coerceIn(0, info.text.length)
-        val safeEnd = end.coerceIn(safeStart, info.text.length)
+        if (isPassword()) return
+        val safeStart = start.coerceAtLeast(0)
+        val safeEnd = end.coerceAtLeast(safeStart)
         connection()?.setSelection(safeStart, safeEnd)
     }
 
-    fun currentSelectionStart(): Int = surroundingText()?.selectionStart ?: 0
+    fun currentSelectionStart(): Int = editorSelection()?.first ?: -1
 
-    fun currentSelectionEnd(): Int = surroundingText()?.selectionEnd ?: currentSelectionStart()
+    fun currentSelectionEnd(): Int = editorSelection()?.second ?: -1
 
-    fun currentTextLength(): Int = surroundingText()?.text?.length ?: 0
+    /** Returns -1 when the available extracted text does not start at document offset 0. */
+    fun currentTextLength(): Int {
+        if (isPassword()) return -1
+        val ic = connection() ?: return -1
+        val window = extractedWindow(ic) ?: return -1
+        return if (window.windowStart == 0) window.text.length else -1
+    }
+
+    /**
+     * Collapse an active selection to its left edge. If absolute editor
+     * coordinates are unavailable, delegate relative movement to the editor.
+     */
+    fun moveSelectionLeft() {
+        val ic = connection() ?: return
+        val selection = editorSelection(ic)
+        if (selection == null) {
+            sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_LEFT)
+            return
+        }
+        val (start, end) = selection
+        val target = if (start != end) minOf(start, end) else (start - 1).coerceAtLeast(0)
+        ic.setSelection(target, target)
+    }
+
+    /**
+     * Collapse an active selection to its right edge. If absolute editor
+     * coordinates are unavailable, delegate relative movement to the editor.
+     */
+    fun moveSelectionRight() {
+        val ic = connection() ?: return
+        val selection = editorSelection(ic)
+        if (selection == null) {
+            sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_RIGHT)
+            return
+        }
+        val (start, end) = selection
+        val target = if (start != end) maxOf(start, end) else end + 1
+        ic.setSelection(target, target)
+    }
 
     fun cursorSnapshot(maxChars: Int = 8_192): CursorSnapshot? {
         if (isPassword()) return null
@@ -158,13 +206,14 @@ class InputConnectionGateway(
     fun copySelection(): String {
         if (isPassword()) return ""
         val ic = connection() ?: return ""
-        val selected = ic.getSelectedText(0)?.toString()
+        val selected = runCatching { ic.getSelectedText(0)?.toString() }.getOrNull()
         if (!selected.isNullOrEmpty()) return selected
-        val info = surroundingText() ?: return ""
-        val start = info.selectionStart
-        val end = info.selectionEnd
-        if (start < 0 || end <= start || end > info.text.length) return ""
-        return info.text.substring(start, end)
+
+        val window = extractedWindow(ic) ?: return ""
+        val localStart = window.selectionStartAbsolute - window.windowStart
+        val localEnd = window.selectionEndAbsolute - window.windowStart
+        if (localStart < 0 || localEnd <= localStart || localEnd > window.text.length) return ""
+        return window.text.substring(localStart, localEnd)
     }
 
     fun copyToClipboard(text: String) {
@@ -196,32 +245,53 @@ class InputConnectionGateway(
     fun commitContent(info: InputContentInfo): Boolean =
         connection()?.commitContent(info, 0, null) == true
 
-    private fun surroundingText(): SurroundingText? {
+    private fun editorSelection(): Pair<Int, Int>? {
         if (isPassword()) return null
         val ic = connection() ?: return null
+        return editorSelection(ic)
+    }
+
+    private fun editorSelection(ic: InputConnection): Pair<Int, Int>? {
+        if (isPassword()) return null
+        val window = extractedWindow(ic) ?: return null
+        return window.selectionStartAbsolute to window.selectionEndAbsolute
+    }
+
+    private fun extractedWindow(ic: InputConnection): ExtractedWindow? {
+        if (isPassword()) return null
         val request = ExtractedTextRequest().apply {
             token = 1
             flags = 0
             hintMaxLines = 1
             hintMaxChars = 0
         }
-        val extracted: ExtractedText? = runCatching { ic.getExtractedText(request, 0) }.getOrNull()
-        if (extracted?.text != null) {
-            val text = extracted.text.toString()
-            val offset = extracted.startOffset.coerceAtLeast(0)
-            val start = (extracted.selectionStart + offset).coerceAtLeast(0)
-            val end = (extracted.selectionEnd + offset).coerceAtLeast(start)
-            return SurroundingText(text, start, end)
-        }
-        val before = ic.getTextBeforeCursor(8192, 0)?.toString() ?: ""
-        val after = ic.getTextAfterCursor(8192, 0)?.toString() ?: ""
-        val start = before.length
-        return SurroundingText(before + after, start, start)
+        val extracted: ExtractedText = runCatching { ic.getExtractedText(request, 0) }.getOrNull()
+            ?: return null
+        val rawText = extracted.text ?: return null
+        if (extracted.selectionStart < 0 || extracted.selectionEnd < 0) return null
+
+        val windowStart = extracted.startOffset.coerceAtLeast(0)
+        val localStart = extracted.selectionStart
+        val localEnd = extracted.selectionEnd
+        val selectionStartAbsolute = windowStart + localStart
+        val selectionEndAbsolute = windowStart + localEnd
+        return ExtractedWindow(
+            text = rawText.toString(),
+            windowStart = windowStart,
+            selectionStartAbsolute = selectionStartAbsolute,
+            selectionEndAbsolute = selectionEndAbsolute,
+        )
     }
 
-    private data class SurroundingText(
+    private fun sendKeyDownUp(ic: InputConnection, keyCode: Int) {
+        ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+        ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+    }
+
+    private data class ExtractedWindow(
         val text: String,
-        val selectionStart: Int,
-        val selectionEnd: Int,
+        val windowStart: Int,
+        val selectionStartAbsolute: Int,
+        val selectionEndAbsolute: Int,
     )
 }

--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -140,56 +140,50 @@ class InputConnectionGateway(
         }
     }
 
-    /** Set an absolute editor selection; do not clamp it to a local extracted window. */
+    /**
+     * Set an editor selection when absolute coordinates are available. If the
+     * editor exposes only a bounded before/after window, a one-character move
+     * is delegated back to the editor through DPAD instead of fabricating an
+     * absolute document coordinate from that local window.
+     */
     fun selectStartEnd(start: Int, end: Int) {
         if (isPassword()) return
-        val safeStart = start.coerceAtLeast(0)
-        val safeEnd = end.coerceAtLeast(safeStart)
-        connection()?.setSelection(safeStart, safeEnd)
+        val ic = connection() ?: return
+        when (val selection = selectionSnapshot(ic)) {
+            is SelectionSnapshot.Absolute -> {
+                val safeStart = start.coerceAtLeast(0)
+                val safeEnd = end.coerceAtLeast(safeStart)
+                ic.setSelection(safeStart, safeEnd)
+            }
+            is SelectionSnapshot.Relative -> {
+                if (start != end) return
+                when (start - selection.cursor) {
+                    -1 -> sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_LEFT)
+                    1 -> sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_RIGHT)
+                }
+            }
+            null -> Unit
+        }
     }
 
-    fun currentSelectionStart(): Int = editorSelection()?.first ?: -1
+    fun currentSelectionStart(): Int = when (val selection = selectionSnapshot()) {
+        is SelectionSnapshot.Absolute -> selection.start
+        is SelectionSnapshot.Relative -> selection.cursor
+        null -> 0
+    }
 
-    fun currentSelectionEnd(): Int = editorSelection()?.second ?: -1
+    fun currentSelectionEnd(): Int = when (val selection = selectionSnapshot()) {
+        is SelectionSnapshot.Absolute -> selection.end
+        is SelectionSnapshot.Relative -> selection.cursor
+        null -> currentSelectionStart()
+    }
 
-    /** Returns -1 when the available extracted text does not start at document offset 0. */
+    /** Returns -1 when the available extracted text does not begin at document offset 0. */
     fun currentTextLength(): Int {
         if (isPassword()) return -1
         val ic = connection() ?: return -1
         val window = extractedWindow(ic) ?: return -1
         return if (window.windowStart == 0) window.text.length else -1
-    }
-
-    /**
-     * Collapse an active selection to its left edge. If absolute editor
-     * coordinates are unavailable, delegate relative movement to the editor.
-     */
-    fun moveSelectionLeft() {
-        val ic = connection() ?: return
-        val selection = editorSelection(ic)
-        if (selection == null) {
-            sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_LEFT)
-            return
-        }
-        val (start, end) = selection
-        val target = if (start != end) minOf(start, end) else (start - 1).coerceAtLeast(0)
-        ic.setSelection(target, target)
-    }
-
-    /**
-     * Collapse an active selection to its right edge. If absolute editor
-     * coordinates are unavailable, delegate relative movement to the editor.
-     */
-    fun moveSelectionRight() {
-        val ic = connection() ?: return
-        val selection = editorSelection(ic)
-        if (selection == null) {
-            sendKeyDownUp(ic, KeyEvent.KEYCODE_DPAD_RIGHT)
-            return
-        }
-        val (start, end) = selection
-        val target = if (start != end) maxOf(start, end) else end + 1
-        ic.setSelection(target, target)
     }
 
     fun cursorSnapshot(maxChars: Int = 8_192): CursorSnapshot? {
@@ -245,16 +239,25 @@ class InputConnectionGateway(
     fun commitContent(info: InputContentInfo): Boolean =
         connection()?.commitContent(info, 0, null) == true
 
-    private fun editorSelection(): Pair<Int, Int>? {
+    private fun selectionSnapshot(): SelectionSnapshot? {
         if (isPassword()) return null
         val ic = connection() ?: return null
-        return editorSelection(ic)
+        return selectionSnapshot(ic)
     }
 
-    private fun editorSelection(ic: InputConnection): Pair<Int, Int>? {
+    private fun selectionSnapshot(ic: InputConnection): SelectionSnapshot? {
         if (isPassword()) return null
-        val window = extractedWindow(ic) ?: return null
-        return window.selectionStartAbsolute to window.selectionEndAbsolute
+        val window = extractedWindow(ic)
+        if (window != null) {
+            return SelectionSnapshot.Absolute(
+                start = window.selectionStartAbsolute,
+                end = window.selectionEndAbsolute,
+            )
+        }
+
+        val before = runCatching { ic.getTextBeforeCursor(FALLBACK_WINDOW_CHARS, 0)?.toString() }
+            .getOrNull() ?: return null
+        return SelectionSnapshot.Relative(cursor = before.length)
     }
 
     private fun extractedWindow(ic: InputConnection): ExtractedWindow? {
@@ -271,15 +274,11 @@ class InputConnectionGateway(
         if (extracted.selectionStart < 0 || extracted.selectionEnd < 0) return null
 
         val windowStart = extracted.startOffset.coerceAtLeast(0)
-        val localStart = extracted.selectionStart
-        val localEnd = extracted.selectionEnd
-        val selectionStartAbsolute = windowStart + localStart
-        val selectionEndAbsolute = windowStart + localEnd
         return ExtractedWindow(
             text = rawText.toString(),
             windowStart = windowStart,
-            selectionStartAbsolute = selectionStartAbsolute,
-            selectionEndAbsolute = selectionEndAbsolute,
+            selectionStartAbsolute = windowStart + extracted.selectionStart,
+            selectionEndAbsolute = windowStart + extracted.selectionEnd,
         )
     }
 
@@ -288,10 +287,19 @@ class InputConnectionGateway(
         ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
     }
 
+    private sealed class SelectionSnapshot {
+        data class Absolute(val start: Int, val end: Int) : SelectionSnapshot()
+        data class Relative(val cursor: Int) : SelectionSnapshot()
+    }
+
     private data class ExtractedWindow(
         val text: String,
         val windowStart: Int,
         val selectionStartAbsolute: Int,
         val selectionEndAbsolute: Int,
     )
+
+    private companion object {
+        const val FALLBACK_WINDOW_CHARS = 8_192
+    }
 }

--- a/app/src/test/java/llc/slacker/openime/InputConnectionGatewayTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputConnectionGatewayTest.kt
@@ -19,6 +19,13 @@ class InputConnectionGatewayTest {
         var beforeText: String = "",
         var afterText: String = "",
         var selectedText: String = "",
+        var extractedText: ExtractedText? = ExtractedText().apply {
+            text = ""
+            selectionStart = 0
+            selectionEnd = 0
+            startOffset = 0
+        },
+        var contextMenuResult: Boolean = false,
     ) : InputConnection {
         val events = mutableListOf<String>()
 
@@ -47,17 +54,15 @@ class InputConnectionGatewayTest {
         }
         override fun getCursorCapsMode(reqType: Int): Int = 0
         override fun getExtractedText(request: ExtractedTextRequest?, flags: Int): ExtractedText? =
-            ExtractedText().apply {
-                text = ""
-                selectionStart = 0
-                selectionEnd = 0
-                startOffset = 0
-            }
+            extractedText
         override fun getHandler(): Handler? = null
         override fun getSelectedText(flags: Int): CharSequence? = selectedText
-        override fun getTextAfterCursor(length: Int, flags: Int): CharSequence? = afterText
-        override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence? = beforeText
-        override fun performContextMenuAction(id: Int): Boolean = false
+        override fun getTextAfterCursor(length: Int, flags: Int): CharSequence? = afterText.take(length)
+        override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence? = beforeText.takeLast(length)
+        override fun performContextMenuAction(id: Int): Boolean {
+            events += "context:$id"
+            return contextMenuResult
+        }
         override fun performEditorAction(editorAction: Int): Boolean {
             events += "action:$editorAction"
             return true
@@ -78,6 +83,18 @@ class InputConnectionGatewayTest {
             events += "selection:$start:$end"
             return true
         }
+    }
+
+    private fun extracted(
+        text: String,
+        startOffset: Int,
+        selectionStart: Int,
+        selectionEnd: Int,
+    ) = ExtractedText().apply {
+        this.text = text
+        this.startOffset = startOffset
+        this.selectionStart = selectionStart
+        this.selectionEnd = selectionEnd
     }
 
     @Test
@@ -125,6 +142,87 @@ class InputConnectionGatewayTest {
         val emoji = "👨‍👩‍👧‍👦"
         gateway.commitText(emoji)
         assertEquals(listOf("commit:$emoji"), fake.events)
+    }
+
+    @Test
+    fun extractedSelectionUsesAbsoluteStartOffsetWithoutLocalClamp() {
+        val fake = FakeInputConnection(
+            extractedText = extracted(
+                text = "0123456789",
+                startOffset = 1_000,
+                selectionStart = 5,
+                selectionEnd = 5,
+            ),
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        assertEquals(1_005, gateway.currentSelectionStart())
+        assertEquals(1_005, gateway.currentSelectionEnd())
+        assertEquals(-1, gateway.currentTextLength())
+
+        gateway.selectStartEnd(1_004, 1_004)
+        assertTrue(fake.events.contains("selection:1004:1004"))
+    }
+
+    @Test
+    fun copySelectionMapsAbsoluteSelectionBackIntoExtractedWindow() {
+        val fake = FakeInputConnection(
+            selectedText = "",
+            extractedText = extracted(
+                text = "0123456789",
+                startOffset = 100,
+                selectionStart = 2,
+                selectionEnd = 5,
+            ),
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        assertEquals("234", gateway.copySelection())
+    }
+
+    @Test
+    fun boundedFallbackUsesRelativeDpadInsteadOfLocalSetSelection() {
+        val fake = FakeInputConnection(
+            beforeText = "x".repeat(20_000),
+            afterText = "tail",
+            extractedText = null,
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        val start = gateway.currentSelectionStart()
+        assertEquals(8_192, start)
+        val left = start.coerceAtLeast(1) - 1
+        gateway.selectStartEnd(left, left)
+
+        assertTrue(fake.events.contains("key:${KeyEvent.KEYCODE_DPAD_LEFT}"))
+        assertTrue(fake.events.none { it.startsWith("selection:") })
+    }
+
+    @Test
+    fun boundedFallbackCanMoveRightRelatively() {
+        val fake = FakeInputConnection(
+            beforeText = "x".repeat(20_000),
+            afterText = "tail",
+            extractedText = null,
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        val end = gateway.currentSelectionEnd()
+        gateway.selectStartEnd(end + 1, end + 1)
+
+        assertTrue(fake.events.contains("key:${KeyEvent.KEYCODE_DPAD_RIGHT}"))
+        assertTrue(fake.events.none { it.startsWith("selection:") })
+    }
+
+    @Test
+    fun selectAllPrefersEditorContextAction() {
+        val fake = FakeInputConnection(contextMenuResult = true)
+        val gateway = InputConnectionGateway(null, { fake })
+
+        gateway.selectAll()
+
+        assertTrue(fake.events.contains("context:${android.R.id.selectAll}"))
+        assertTrue(fake.events.none { it.startsWith("selection:") })
     }
 
     @Test

--- a/app/src/test/java/llc/slacker/openime/InputConnectionGatewayTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputConnectionGatewayTest.kt
@@ -10,6 +10,7 @@ import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -181,7 +182,7 @@ class InputConnectionGatewayTest {
     }
 
     @Test
-    fun boundedFallbackUsesRelativeDpadInsteadOfLocalSetSelection() {
+    fun boundedFallbackExposesRelativeCursorWithoutFabricatingSelection() {
         val fake = FakeInputConnection(
             beforeText = "x".repeat(20_000),
             afterText = "tail",
@@ -189,29 +190,18 @@ class InputConnectionGatewayTest {
         )
         val gateway = InputConnectionGateway(null, { fake })
 
-        val start = gateway.currentSelectionStart()
-        assertEquals(8_192, start)
-        val left = start.coerceAtLeast(1) - 1
-        gateway.selectStartEnd(left, left)
-
-        assertTrue(fake.events.contains("key:${KeyEvent.KEYCODE_DPAD_LEFT}"))
+        assertEquals(8_192, gateway.currentSelectionStart())
+        assertEquals(8_192, gateway.currentSelectionEnd())
+        gateway.selectStartEnd(8_192, 8_192)
         assertTrue(fake.events.none { it.startsWith("selection:") })
     }
 
     @Test
-    fun boundedFallbackCanMoveRightRelatively() {
-        val fake = FakeInputConnection(
-            beforeText = "x".repeat(20_000),
-            afterText = "tail",
-            extractedText = null,
-        )
-        val gateway = InputConnectionGateway(null, { fake })
-
-        val end = gateway.currentSelectionEnd()
-        gateway.selectStartEnd(end + 1, end + 1)
-
-        assertTrue(fake.events.contains("key:${KeyEvent.KEYCODE_DPAD_RIGHT}"))
-        assertTrue(fake.events.none { it.startsWith("selection:") })
+    fun relativeCursorDeltaMapsToDpadKeys() {
+        assertEquals(KeyEvent.KEYCODE_DPAD_LEFT, relativeCursorKeyCode(-1))
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, relativeCursorKeyCode(1))
+        assertNull(relativeCursorKeyCode(0))
+        assertNull(relativeCursorKeyCode(2))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stop clamping absolute ExtractedText selections to local window length
- map `startOffset + selectionStart/End` correctly for partial extracted windows
- map copied selections back into the extracted window before slicing
- when `getExtractedText()` is unavailable, treat the bounded before-cursor position as relative only and delegate ±1 cursor movement to the editor with DPAD events
- prefer the editor's context-menu implementation for select-all instead of assuming a bounded window is the full document
- return unknown text length for non-zero extracted start offsets
- add regression tests for non-zero `startOffset`, null ExtractedText with long documents, relative left/right movement, copy-selection mapping, and select-all delegation

Closes #3

## Notes
This deliberately does not close #25 yet: selection-collapse semantics with an active range remain a separate behavior fix.