### PR TITLE
Fix voice audio route ownership across rapid restarts

### DIFF
--- a/app/src/main/java/llc/slacker/openime/VoiceAudioRouteManager.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceAudioRouteManager.kt
@@ -5,6 +5,7 @@ import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -56,7 +57,7 @@ class VoiceAudioRouteManager(context: Context) {
     private val ownership = VoiceRouteOwnership<RouteBaseline>()
 
     fun beginSession(): Session {
-        if (Build.VERSION.SDK_INT < 31) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             // VOICE_RECOGNITION follows the system-selected wired/SCO route on
             // old Android versions. Do not force SCO and introduce a 500 ms
             // startup gap; keep the policy isolated here for later tuning.
@@ -79,6 +80,7 @@ class VoiceAudioRouteManager(context: Context) {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.S)
     private fun prepareManagedRoute(): RouteBaseline {
         val previousMode = audioManager.mode
         val previousDevice = runCatching { audioManager.communicationDevice }.getOrNull()
@@ -104,6 +106,7 @@ class VoiceAudioRouteManager(context: Context) {
         )
     }
 
+    @RequiresApi(Build.VERSION_CODES.S)
     private fun restoreManagedRoute(baseline: RouteBaseline) {
         if (baseline.changedDevice) {
             runCatching {
@@ -119,8 +122,8 @@ class VoiceAudioRouteManager(context: Context) {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.S)
     private fun preferredExternalDevice(): AudioDeviceInfo? {
-        if (Build.VERSION.SDK_INT < 31) return null
         val priority = listOf(
             AudioDeviceInfo.TYPE_BLE_HEADSET,
             AudioDeviceInfo.TYPE_BLUETOOTH_SCO,

--- a/app/src/main/java/llc/slacker/openime/VoiceAudioRouteManager.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceAudioRouteManager.kt
@@ -7,17 +7,55 @@ import android.os.Build
 import android.util.Log
 import java.util.concurrent.atomic.AtomicBoolean
 
+/**
+ * Keeps one original baseline across overlapping sessions and allows only the
+ * latest owner to restore it. Preparation and restoration run under the same
+ * lock so a new owner cannot snapshot a half-restored route.
+ */
+internal class VoiceRouteOwnership<T : Any> {
+    data class Lease(val owner: Long, val firstOwner: Boolean)
+
+    private val lock = Any()
+    private var generation = 0L
+    private var baseline: T? = null
+
+    fun acquire(prepareBaseline: () -> T): Lease = synchronized(lock) {
+        generation += 1
+        val firstOwner = baseline == null
+        if (firstOwner) baseline = prepareBaseline()
+        Lease(owner = generation, firstOwner = firstOwner)
+    }
+
+    fun release(owner: Long, restoreBaseline: (T) -> Unit): Boolean = synchronized(lock) {
+        if (owner != generation) return@synchronized false
+        val value = baseline ?: return@synchronized false
+        // Invalidate this owner before restoration. A future acquire cannot
+        // interleave because restoreBaseline still runs under this same lock.
+        generation += 1
+        baseline = null
+        restoreBaseline(value)
+        true
+    }
+}
+
 /** Keeps device routing policy separate from capture and ASR inference. */
 class VoiceAudioRouteManager(context: Context) {
     companion object {
         private const val TAG = "OpenImeVoiceRoute"
     }
 
+    private data class RouteBaseline(
+        val previousMode: Int,
+        val previousDevice: AudioDeviceInfo?,
+        val changedMode: Boolean,
+        val changedDevice: Boolean,
+    )
+
     private val audioManager = context.applicationContext
         .getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val ownership = VoiceRouteOwnership<RouteBaseline>()
 
     fun beginSession(): Session {
-        val previousMode = audioManager.mode
         if (Build.VERSION.SDK_INT < 31) {
             // VOICE_RECOGNITION follows the system-selected wired/SCO route on
             // old Android versions. Do not force SCO and introduce a 500 ms
@@ -26,6 +64,23 @@ class VoiceAudioRouteManager(context: Context) {
             return Session(onClose = {})
         }
 
+        val lease = ownership.acquire { prepareManagedRoute() }
+        val activeType = runCatching { audioManager.communicationDevice?.type ?: 0 }.getOrDefault(0)
+        Log.i(
+            TAG,
+            "routeSession api=${Build.VERSION.SDK_INT} type=$activeType firstOwner=${lease.firstOwner}",
+        )
+
+        return Session {
+            val restored = ownership.release(lease.owner, ::restoreManagedRoute)
+            if (!restored) {
+                Log.d(TAG, "ignoreStaleRouteClose owner=${lease.owner}")
+            }
+        }
+    }
+
+    private fun prepareManagedRoute(): RouteBaseline {
+        val previousMode = audioManager.mode
         val previousDevice = runCatching { audioManager.communicationDevice }.getOrNull()
         val preferred = if (previousDevice == null) preferredExternalDevice() else null
         var changedMode = false
@@ -41,20 +96,26 @@ class VoiceAudioRouteManager(context: Context) {
                 Log.w(TAG, "routeSelectionFailed type=${preferred.type}")
             }
         }
-        val activeType = runCatching { audioManager.communicationDevice?.type ?: 0 }.getOrDefault(0)
-        Log.i(TAG, "routeSession api=${Build.VERSION.SDK_INT} type=$activeType managed=$changedDevice")
+        return RouteBaseline(
+            previousMode = previousMode,
+            previousDevice = previousDevice,
+            changedMode = changedMode,
+            changedDevice = changedDevice,
+        )
+    }
 
-        return Session {
-            if (changedDevice) {
-                runCatching {
-                    if (previousDevice != null) {
-                        audioManager.setCommunicationDevice(previousDevice)
-                    } else {
-                        audioManager.clearCommunicationDevice()
-                    }
+    private fun restoreManagedRoute(baseline: RouteBaseline) {
+        if (baseline.changedDevice) {
+            runCatching {
+                if (baseline.previousDevice != null) {
+                    audioManager.setCommunicationDevice(baseline.previousDevice)
+                } else {
+                    audioManager.clearCommunicationDevice()
                 }
             }
-            if (changedMode) runCatching { audioManager.mode = previousMode }
+        }
+        if (baseline.changedMode) {
+            runCatching { audioManager.mode = baseline.previousMode }
         }
     }
 

--- a/app/src/main/java/llc/slacker/openime/VoiceAudioRouteManager.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceAudioRouteManager.kt
@@ -1,11 +1,11 @@
 package llc.slacker.openime
 
+import android.annotation.TargetApi
 import android.content.Context
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
 import android.util.Log
-import androidx.annotation.RequiresApi
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -80,7 +80,7 @@ class VoiceAudioRouteManager(context: Context) {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
+    @TargetApi(Build.VERSION_CODES.S)
     private fun prepareManagedRoute(): RouteBaseline {
         val previousMode = audioManager.mode
         val previousDevice = runCatching { audioManager.communicationDevice }.getOrNull()
@@ -106,7 +106,7 @@ class VoiceAudioRouteManager(context: Context) {
         )
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
+    @TargetApi(Build.VERSION_CODES.S)
     private fun restoreManagedRoute(baseline: RouteBaseline) {
         if (baseline.changedDevice) {
             runCatching {
@@ -122,7 +122,7 @@ class VoiceAudioRouteManager(context: Context) {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
+    @TargetApi(Build.VERSION_CODES.S)
     private fun preferredExternalDevice(): AudioDeviceInfo? {
         val priority = listOf(
             AudioDeviceInfo.TYPE_BLE_HEADSET,

--- a/app/src/test/java/llc/slacker/openime/VoiceAudioRouteManagerTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoiceAudioRouteManagerTest.kt
@@ -1,0 +1,60 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceAudioRouteManagerTest {
+
+    @Test
+    fun staleOwnerCannotRestoreAfterNewSessionTakesOwnership() {
+        val ownership = VoiceRouteOwnership<String>()
+        var prepareCount = 0
+        val restored = mutableListOf<String>()
+
+        val first = ownership.acquire {
+            prepareCount += 1
+            "original-route"
+        }
+        val second = ownership.acquire {
+            prepareCount += 1
+            "must-not-replace-baseline"
+        }
+
+        assertTrue(first.firstOwner)
+        assertFalse(second.firstOwner)
+        assertEquals(1, prepareCount)
+        assertFalse(ownership.release(first.owner, restored::add))
+        assertTrue(restored.isEmpty())
+
+        assertTrue(ownership.release(second.owner, restored::add))
+        assertEquals(listOf("original-route"), restored)
+    }
+
+    @Test
+    fun nextIndependentSessionCapturesANewBaselineAfterRestore() {
+        val ownership = VoiceRouteOwnership<String>()
+        val restored = mutableListOf<String>()
+
+        val first = ownership.acquire { "route-a" }
+        assertTrue(ownership.release(first.owner, restored::add))
+
+        val second = ownership.acquire { "route-b" }
+        assertTrue(second.firstOwner)
+        assertTrue(ownership.release(second.owner, restored::add))
+
+        assertEquals(listOf("route-a", "route-b"), restored)
+    }
+
+    @Test
+    fun alreadyReleasedOwnerCannotRestoreTwice() {
+        val ownership = VoiceRouteOwnership<String>()
+        val restored = mutableListOf<String>()
+        val lease = ownership.acquire { "route" }
+
+        assertTrue(ownership.release(lease.owner, restored::add))
+        assertFalse(ownership.release(lease.owner, restored::add))
+        assertEquals(listOf("route"), restored)
+    }
+}


### PR DESCRIPTION
## Summary
- keep one original AudioManager baseline across overlapping voice sessions
- transfer route ownership to the newest session without re-snapshotting an already modified route
- ignore stale session close calls
- serialize route preparation/restoration so a new session cannot snapshot a half-restored state
- restore the original device/mode only when the current owner closes
- add JVM tests for stale-owner close, baseline handoff, and double-release behavior

Closes #8