### PR TITLE
Scope Sherpa streams to individual voice sessions

### DIFF
--- a/app/src/main/java/llc/slacker/openime/LocalAudioVoiceBackend.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalAudioVoiceBackend.kt
@@ -181,8 +181,8 @@ class LocalAudioVoiceBackend(
 
     @SuppressLint("MissingPermission")
     override fun start(languageTag: String, events: VoiceRecognitionEvents) {
-        // A new gesture replaces an unfinished old one. Do not let two model
-        // streams share the same runtime.
+        // A new gesture replaces an unfinished old one. Each gesture receives
+        // its own model stream handle, so stale cleanup cannot stop a new one.
         cancel()
         if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
             events.onError("当前未授予麦克风权限，请在系统设置中授权后重试")
@@ -316,8 +316,7 @@ class LocalAudioVoiceBackend(
             // already live and the bounded ring keeps the spoken prefix.
             val model = runtimeProvider.awaitRuntime()
                 ?: throw IllegalStateException("本地语音模型尚未内置或加载失败")
-            session.runtime = model
-            model.start(languageTag, modelEvents)
+            session.voiceSession = model.openSession(languageTag, modelEvents)
             if (!isCurrent(generation, session) || session.cancelled.get() || session.failed.get()) {
                 cleanupStartingSession(session)
                 return
@@ -371,7 +370,8 @@ class LocalAudioVoiceBackend(
         value.running.set(false)
         runCatching { value.record.stop() }
         value.ring.wake()
-        runCatching { value.runtime?.stop() }
+        runCatching { value.voiceSession?.close() }
+        value.voiceSession = null
         runCatching { value.record.release() }
         value.routeSession.close()
         value.ring.clear()
@@ -437,7 +437,7 @@ class LocalAudioVoiceBackend(
     }
 
     private fun inferenceLoop(session: Session) {
-        val runtime = checkNotNull(session.runtime) { "本地语音模型尚未连接" }
+        val voiceSession = checkNotNull(session.voiceSession) { "本地语音模型尚未连接" }
         val pending = ShortArray(LocalVoiceAudioSpec.CHUNK_SAMPLES)
         var pendingCount = 0
         try {
@@ -455,20 +455,20 @@ class LocalAudioVoiceBackend(
                 val chunk = pending.copyOf(pendingCount)
                 pendingCount = 0
                 VoicePerformanceTrace.markFirstDecode()
-                runtime.acceptWaveform(pcm16ToFloat(chunk))
+                voiceSession.acceptWaveform(pcm16ToFloat(chunk))
             }
             if (pendingCount > 0) {
                 VoicePerformanceTrace.markFirstDecode()
-                runtime.acceptWaveform(pcm16ToFloat(pending.copyOf(pendingCount)))
+                voiceSession.acceptWaveform(pcm16ToFloat(pending.copyOf(pendingCount)))
             }
             if (
                 !session.failed.get() &&
                 !session.cancelled.get() &&
                 session.finished.compareAndSet(false, true)
             ) {
-                val raw = runtime.inputFinished().ifBlank { session.lastPartial }
+                val raw = voiceSession.inputFinished().ifBlank { session.lastPartial }
                 VoicePerformanceTrace.markFinalAsr()
-                val punctuated = if (raw.isBlank()) raw else runtime.punctuate(raw) ?: raw
+                val punctuated = if (raw.isBlank()) raw else voiceSession.punctuate(raw) ?: raw
                 val final = VoiceCorrectionRepository.apply(punctuated)
                 VoicePerformanceTrace.markPunctuationDone()
                 session.events.onFinal(final)
@@ -477,7 +477,8 @@ class LocalAudioVoiceBackend(
         } catch (error: Throwable) {
             fail(session, "本地语音推理失败：${error.message.orEmpty()}")
         } finally {
-            runCatching { runtime.stop() }
+            runCatching { voiceSession.close() }
+            session.voiceSession = null
             session.ring.clear()
             session.routeSession.close()
             synchronized(lock) {
@@ -504,7 +505,7 @@ class LocalAudioVoiceBackend(
         val routeSession: VoiceAudioRouteManager.Session,
     ) {
         @Volatile
-        var runtime: StreamingEmbeddedVoiceModelRuntime? = null
+        var voiceSession: StreamingVoiceModelSession? = null
         val running = AtomicBoolean(false)
         val stopRequested = AtomicBoolean(false)
         val cancelled = AtomicBoolean(false)

--- a/app/src/main/java/llc/slacker/openime/VoiceRecognitionBackend.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceRecognitionBackend.kt
@@ -7,6 +7,7 @@ import com.k2fsa.sherpa.onnx.OnlineRecognizer
 import com.k2fsa.sherpa.onnx.OnlineRecognizerConfig
 import com.k2fsa.sherpa.onnx.OnlineStream
 import com.k2fsa.sherpa.onnx.OnlineTransducerModelConfig
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Stable voice boundary used by the keyboard UI. The production contract is
@@ -50,25 +51,48 @@ interface EmbeddedVoiceModelRuntime {
     fun stop()
 }
 
+/** One independently owned streaming decode session. */
+interface StreamingVoiceModelSession : AutoCloseable {
+    fun acceptWaveform(samples: FloatArray)
+
+    /** Finish this stream and return the raw ASR text. */
+    fun inputFinished(): String
+
+    /** Run punctuation once at the end; null means punctuation failed. */
+    fun punctuate(text: String): String?
+}
+
 /**
- * Audio-facing contract for the bundled streaming runtime. The runtime keeps
- * its OnlineStream state between calls; the IME never sends the whole
- * recording back through the model on every partial result.
+ * Audio-facing contract for the bundled streaming runtime. The recognizer is
+ * shared and preloaded, but each long-press receives an independent stream
+ * handle so stale session cleanup cannot release a newer session's stream.
  */
 interface StreamingEmbeddedVoiceModelRuntime : EmbeddedVoiceModelRuntime {
     /** Map and initialize the local recognizer without starting a voice session. */
     fun preload()
 
-    fun acceptWaveform(samples: FloatArray)
-
-    /** Finish the current stream and return the raw ASR text. */
-    fun inputFinished(): String
-
-    /** Run punctuation once at the end; null means punctuation failed. */
-    fun punctuate(text: String): String?
+    fun openSession(
+        languageTag: String,
+        events: VoiceRecognitionEvents,
+    ): StreamingVoiceModelSession
 
     /** Release all native model resources after the IME cooldown expires. */
     fun release()
+}
+
+/** A small idempotent owner used so each voice session releases only its resource. */
+internal class VoiceStreamLease<T : Any>(
+    val value: T,
+    private val releaseResource: (T) -> Unit,
+) : AutoCloseable {
+    private val closed = AtomicBoolean(false)
+
+    val isClosed: Boolean
+        get() = closed.get()
+
+    override fun close() {
+        if (closed.compareAndSet(false, true)) releaseResource(value)
+    }
 }
 
 /**
@@ -170,21 +194,58 @@ private class SherpaOnnxStreamingRuntime(
         private const val TOKENS = "$MODEL_ROOT/tokens.txt"
     }
 
+    private val runtimeLock = Any()
     private var recognizer: OnlineRecognizer? = null
-    private var stream: OnlineStream? = null
-    private var events: VoiceRecognitionEvents? = null
-    private var lastPartial = ""
-    private var languageTag = "zh-CN"
+    private val activeSessions = mutableSetOf<SherpaSession>()
+    private var legacySession: SherpaSession? = null
 
     override val isReady: Boolean
         get() = manifest.modelType == "zipformer" && manifest.files.containsAll(
             listOf(ENCODER, DECODER, JOINER, TOKENS),
         )
 
-    @Synchronized
     override fun preload() {
-        if (recognizer != null) return
-        recognizer = OnlineRecognizer(
+        synchronized(runtimeLock) {
+            ensureRecognizerLocked()
+        }
+    }
+
+    override fun openSession(
+        languageTag: String,
+        events: VoiceRecognitionEvents,
+    ): StreamingVoiceModelSession = synchronized(runtimeLock) {
+        check(isReady) { "内置语音模型清单或文件不完整" }
+        openSessionLocked(languageTag, events)
+    }
+
+    /** Legacy non-AudioRecord path retained for the generic runtime boundary. */
+    override fun start(languageTag: String, events: VoiceRecognitionEvents) {
+        synchronized(runtimeLock) {
+            legacySession?.closeLocked()
+            legacySession = openSessionLocked(languageTag, events)
+        }
+    }
+
+    override fun stop() {
+        synchronized(runtimeLock) {
+            legacySession?.closeLocked()
+            legacySession = null
+        }
+    }
+
+    override fun release() {
+        synchronized(runtimeLock) {
+            activeSessions.toList().forEach { it.closeLocked() }
+            legacySession = null
+            recognizer?.release()
+            recognizer = null
+        }
+    }
+
+    private fun ensureRecognizerLocked(): OnlineRecognizer {
+        recognizer?.let { return it }
+        check(isReady) { "内置语音模型清单或文件不完整" }
+        return OnlineRecognizer(
             context.assets,
             OnlineRecognizerConfig(
                 featConfig = FeatureConfig(sampleRate = SAMPLE_RATE, featureDim = 80),
@@ -205,69 +266,96 @@ private class SherpaOnnxStreamingRuntime(
                 maxActivePaths = 4,
                 hotwordsScore = 1.8f,
             ),
-        )
+        ).also { recognizer = it }
     }
 
-    override fun start(languageTag: String, events: VoiceRecognitionEvents) {
-        check(isReady) { "内置语音模型清单或文件不完整" }
-        preload()
-        stream?.release()
+    private fun openSessionLocked(
+        languageTag: String,
+        events: VoiceRecognitionEvents,
+    ): SherpaSession {
+        val currentRecognizer = ensureRecognizerLocked()
         val hotwords = VoiceHotwordProvider.current()
-        stream = if (hotwords.isBlank()) {
-            recognizer?.createStream()
+        val stream = if (hotwords.isBlank()) {
+            currentRecognizer.createStream()
         } else {
-            recognizer?.createStream(hotwords)
+            currentRecognizer.createStream(hotwords)
         }
-        this.events = events
-        this.languageTag = languageTag
-        lastPartial = ""
+        return SherpaSession(
+            streamLease = VoiceStreamLease(stream) { it.release() },
+            languageTag = languageTag,
+            events = events,
+        ).also(activeSessions::add)
     }
 
-    override fun acceptWaveform(samples: FloatArray) {
-        val currentRecognizer = checkNotNull(recognizer) { "语音识别器尚未启动" }
-        val currentStream = checkNotNull(stream) { "语音流尚未启动" }
-        if (samples.isEmpty()) return
-        currentStream.acceptWaveform(samples, SAMPLE_RATE)
-        decodeReady(currentRecognizer, currentStream)
-    }
+    private inner class SherpaSession(
+        private val streamLease: VoiceStreamLease<OnlineStream>,
+        private val languageTag: String,
+        private val events: VoiceRecognitionEvents,
+    ) : StreamingVoiceModelSession {
+        private var lastPartial = ""
 
-    override fun inputFinished(): String {
-        val currentRecognizer = recognizer ?: return lastPartial
-        val currentStream = stream ?: return lastPartial
-        currentStream.inputFinished()
-        decodeReady(currentRecognizer, currentStream)
-        return currentRecognizer.getResult(currentStream).text.trim().also { lastPartial = it }
-    }
-
-    override fun punctuate(text: String): String = VoiceTextProcessor.process(text, languageTag)
-
-    override fun stop() {
-        stream?.release()
-        stream = null
-        events = null
-        lastPartial = ""
-        // Keep the recognizer mapped. The next long-press can start promptly
-        // without remapping the large encoder into the IME process.
-    }
-
-    @Synchronized
-    override fun release() {
-        stream?.release()
-        stream = null
-        recognizer?.release()
-        recognizer = null
-        events = null
-        lastPartial = ""
-    }
-
-    private fun decodeReady(currentRecognizer: OnlineRecognizer, currentStream: OnlineStream) {
-        while (currentRecognizer.isReady(currentStream)) {
-            currentRecognizer.decode(currentStream)
-            val text = currentRecognizer.getResult(currentStream).text.trim()
-            if (text.isNotEmpty() && text != lastPartial) {
-                lastPartial = text
-                events?.onPartial(text)
+        override fun acceptWaveform(samples: FloatArray) {
+            if (samples.isEmpty()) return
+            val partials = synchronized(runtimeLock) {
+                checkOpenLocked()
+                val currentRecognizer = checkNotNull(recognizer) { "语音识别器已释放" }
+                val currentStream = streamLease.value
+                currentStream.acceptWaveform(samples, SAMPLE_RATE)
+                decodeReadyLocked(currentRecognizer, currentStream)
             }
+            partials.forEach(events::onPartial)
+        }
+
+        override fun inputFinished(): String {
+            val (result, partials) = synchronized(runtimeLock) {
+                checkOpenLocked()
+                val currentRecognizer = checkNotNull(recognizer) { "语音识别器已释放" }
+                val currentStream = streamLease.value
+                currentStream.inputFinished()
+                val decoded = decodeReadyLocked(currentRecognizer, currentStream)
+                val final = currentRecognizer.getResult(currentStream).text.trim()
+                    .ifBlank { lastPartial }
+                lastPartial = final
+                final to decoded
+            }
+            partials.forEach(events::onPartial)
+            return result
+        }
+
+        override fun punctuate(text: String): String = VoiceTextProcessor.process(text, languageTag)
+
+        override fun close() {
+            synchronized(runtimeLock) {
+                closeLocked()
+            }
+        }
+
+        fun closeLocked() {
+            if (streamLease.isClosed) return
+            streamLease.close()
+            activeSessions.remove(this)
+            if (legacySession === this) legacySession = null
+            lastPartial = ""
+        }
+
+        private fun checkOpenLocked() {
+            check(!streamLease.isClosed) { "语音流已经结束" }
+        }
+
+        private fun decodeReadyLocked(
+            currentRecognizer: OnlineRecognizer,
+            currentStream: OnlineStream,
+        ): List<String> {
+            val emitted = mutableListOf<String>()
+            while (currentRecognizer.isReady(currentStream)) {
+                currentRecognizer.decode(currentStream)
+                val text = currentRecognizer.getResult(currentStream).text.trim()
+                if (text.isNotEmpty() && text != lastPartial) {
+                    lastPartial = text
+                    emitted += text
+                }
+            }
+            return emitted
         }
     }
 }

--- a/app/src/test/java/llc/slacker/openime/LocalAudioVoiceBackendTest.kt
+++ b/app/src/test/java/llc/slacker/openime/LocalAudioVoiceBackendTest.kt
@@ -29,4 +29,21 @@ class LocalAudioVoiceBackendTest {
         assertEquals(0f, result[1], 0.0001f)
         assertTrue(result[2] > 0.99f && result[2] <= 1f)
     }
+
+    @Test
+    fun closingOldStreamLeaseCannotReleaseNewStream() {
+        val released = mutableListOf<String>()
+        val old = VoiceStreamLease("stream-a", released::add)
+        val current = VoiceStreamLease("stream-b", released::add)
+
+        old.close()
+        old.close()
+
+        assertEquals(listOf("stream-a"), released)
+        assertTrue(current.isClosed.not())
+        assertEquals("stream-b", current.value)
+
+        current.close()
+        assertEquals(listOf("stream-a", "stream-b"), released)
+    }
 }


### PR DESCRIPTION
## Summary
- add `StreamingVoiceModelSession` so each long-press owns an independent Sherpa `OnlineStream`
- keep the large `OnlineRecognizer` shared/preloaded across sessions
- make `LocalAudioVoiceBackend` store and close the per-session stream handle instead of calling `stop()` on the shared runtime
- serialize recognizer/stream native operations behind one runtime lock
- close all active streams before releasing the shared recognizer
- retain the generic legacy `EmbeddedVoiceModelRuntime.start/stop` boundary without using it in the production streaming AudioRecord path
- add an idempotent per-stream lease and regression test proving stale cleanup cannot release a newer stream

Closes #7

## Race fixed
Before this change, session A could be cancelled, session B could replace the runtime's global `stream`, and A's delayed `finally { runtime.stop() }` would release B. After this change A's `finally` only closes A's own session handle.