### PR TITLE
Do not persist sensitive clipboard contents

### DIFF
--- a/app/src/main/java/llc/slacker/openime/ClipboardHistoryRepository.kt
+++ b/app/src/main/java/llc/slacker/openime/ClipboardHistoryRepository.kt
@@ -11,6 +11,17 @@ data class ClipboardEntry(
     val pinned: Boolean = false,
 )
 
+internal object ClipboardSensitivityPolicy {
+    // ClipDescription.EXTRA_IS_SENSITIVE was added as a public constant in
+    // API 33, but this literal is the compatibility key Android documents for
+    // older releases as well. Keeping the literal avoids any runtime API-level
+    // dependency while preserving the same contract on API 26+.
+    const val SENSITIVE_KEY = "android.content.extra.IS_SENSITIVE"
+
+    fun isSensitive(readBoolean: (String) -> Boolean): Boolean =
+        runCatching { readBoolean(SENSITIVE_KEY) }.getOrDefault(false)
+}
+
 /**
  * Tiny persistent clipboard history. Clipboard capture is best-effort and is
  * skipped by the caller for password fields; no clipboard content is logged.
@@ -52,6 +63,12 @@ object ClipboardHistoryRepository {
     fun capturePrimary(context: Context): Boolean {
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
             ?: return false
+        val description = runCatching { clipboard.primaryClipDescription }.getOrNull()
+        val sensitive = description?.extras?.let { extras ->
+            ClipboardSensitivityPolicy.isSensitive { key -> extras.getBoolean(key, false) }
+        } ?: false
+        if (sensitive) return false
+
         val text = runCatching {
             clipboard.primaryClip
                 ?.takeIf { it.itemCount > 0 }

--- a/app/src/test/java/llc/slacker/openime/ClipboardSensitivityPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ClipboardSensitivityPolicyTest.kt
@@ -1,0 +1,35 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardSensitivityPolicyTest {
+    @Test
+    fun sensitiveCompatibilityFlagBlocksPersistence() {
+        assertTrue(
+            ClipboardSensitivityPolicy.isSensitive { key ->
+                key == "android.content.extra.IS_SENSITIVE"
+            },
+        )
+    }
+
+    @Test
+    fun absentOrFalseFlagAllowsNormalClipboardHistory() {
+        assertFalse(ClipboardSensitivityPolicy.isSensitive { false })
+        assertFalse(
+            ClipboardSensitivityPolicy.isSensitive { key ->
+                key == "some.other.flag"
+            },
+        )
+    }
+
+    @Test
+    fun malformedExtrasReaderFailsClosedToNormalBehavior() {
+        assertFalse(
+            ClipboardSensitivityPolicy.isSensitive {
+                error("bad extras")
+            },
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- inspect the system clipboard sensitivity flag before reading/persisting primary clip text
- use the documented compatibility key `android.content.extra.IS_SENSITIVE` so the policy works across the app's API 26+ range
- return without adding to `ime_clipboard_history` when the flag is true
- keep ordinary clipboard history behavior unchanged
- add pure JVM coverage for the sensitivity policy

Refs #15

This intentionally addresses the definite persistence bug only. Password-field rendering of existing clipboard history is a separate product-policy decision and is not changed here.