### PR TITLE
Make Rime startup and shutdown lifecycle-safe

### DIFF
--- a/app/src/androidTest/java/llc/slacker/openime/RimeNativeUnicodeInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/RimeNativeUnicodeInstrumentedTest.kt
@@ -1,0 +1,16 @@
+package llc.slacker.openime
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RimeNativeUnicodeInstrumentedTest {
+    @Test
+    fun nativeBoundaryRoundTripsBmpAndNonBmpUnicode() {
+        val value = "中文𠀀😀é"
+
+        assertEquals(value, RimeNative.nativeUtf8RoundTripForTest(value))
+    }
+}

--- a/app/src/main/cpp/local_rime_jni.cc
+++ b/app/src/main/cpp/local_rime_jni.cc
@@ -12,7 +12,7 @@ namespace {
 std::mutex g_mutex;
 RimeApi* g_api = nullptr;
 RimeSessionId g_session = 0;
-bool g_started = false;
+bool g_initialized = false;
 
 std::string jstring_to_string(JNIEnv* env, jstring value) {
   if (!value) return {};
@@ -102,13 +102,26 @@ std::vector<std::string> snapshot_locked() {
   return values;
 }
 
+void shutdown_locked() {
+  if (g_api && g_session) g_api->destroy_session(g_session);
+  g_session = 0;
+  // initialize() can succeed even when create_session()/schema selection later
+  // fails. Track initialization independently so every partial startup is
+  // finalized and a subsequent startup begins from a clean process state.
+  if (g_api && g_initialized) g_api->finalize();
+  g_api = nullptr;
+  g_initialized = false;
+}
+
 }  // namespace
 
 extern "C" JNIEXPORT void JNICALL
 Java_llc_slacker_openime_RimeNative_nativeStartup(
     JNIEnv* env, jclass, jstring shared_dir, jstring user_dir) {
   std::lock_guard<std::mutex> lock(g_mutex);
-  if (g_started) return;
+  if (g_api && g_session) return;
+  // Recover from any previous partial initialization before retrying.
+  if (g_api || g_initialized) shutdown_locked();
 
   const std::string shared = jstring_to_string(env, shared_dir);
   const std::string user = jstring_to_string(env, user_dir);
@@ -128,6 +141,7 @@ Java_llc_slacker_openime_RimeNative_nativeStartup(
   traits.log_dir = "";
   g_api->setup(&traits);
   g_api->initialize(&traits);
+  g_initialized = true;
 
   // Deployment is performed off the Android main thread by RimeEngine. Wait
   // here so the first keyboard session never races schema generation.
@@ -144,7 +158,6 @@ Java_llc_slacker_openime_RimeNative_nativeStartup(
       g_api->select_schema(g_session, "luna_pinyin");
     }
   }
-  g_started = g_session != 0;
 }
 
 extern "C" JNIEXPORT jobjectArray JNICALL
@@ -200,9 +213,5 @@ extern "C" JNIEXPORT void JNICALL
 Java_llc_slacker_openime_RimeNative_nativeShutdown(
     JNIEnv*, jclass) {
   std::lock_guard<std::mutex> lock(g_mutex);
-  if (g_api && g_session) g_api->destroy_session(g_session);
-  g_session = 0;
-  if (g_api && g_started) g_api->finalize();
-  g_api = nullptr;
-  g_started = false;
+  shutdown_locked();
 }

--- a/app/src/main/cpp/local_rime_jni.cc
+++ b/app/src/main/cpp/local_rime_jni.cc
@@ -153,10 +153,17 @@ Java_llc_slacker_openime_RimeNative_nativeStartup(
   }
 
   g_session = g_api->create_session();
-  if (g_session && g_api->select_schema) {
-    if (!g_api->select_schema(g_session, "luna_pinyin_simp")) {
-      g_api->select_schema(g_session, "luna_pinyin");
-    }
+  if (!g_session) return;
+
+  // A live session is not sufficient: without a selected schema every later
+  // candidate query is empty. Require one of the bundled Pinyin schemas.
+  const bool schema_selected =
+      g_api->select_schema &&
+      (g_api->select_schema(g_session, "luna_pinyin_simp") ||
+       g_api->select_schema(g_session, "luna_pinyin"));
+  if (!schema_selected) {
+    g_api->destroy_session(g_session);
+    g_session = 0;
   }
 }
 

--- a/app/src/main/cpp/local_rime_jni.cc
+++ b/app/src/main/cpp/local_rime_jni.cc
@@ -1,5 +1,6 @@
 #include <jni.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <mutex>
 #include <string>
@@ -14,13 +15,132 @@ RimeApi* g_api = nullptr;
 RimeSessionId g_session = 0;
 bool g_initialized = false;
 
-std::string jstring_to_string(JNIEnv* env, jstring value) {
+constexpr uint32_t kReplacementCharacter = 0xFFFD;
+
+void append_utf8(std::string* out, uint32_t code_point) {
+  if (!out) return;
+  if (code_point <= 0x7F) {
+    out->push_back(static_cast<char>(code_point));
+  } else if (code_point <= 0x7FF) {
+    out->push_back(static_cast<char>(0xC0 | (code_point >> 6)));
+    out->push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
+  } else if (code_point <= 0xFFFF) {
+    out->push_back(static_cast<char>(0xE0 | (code_point >> 12)));
+    out->push_back(static_cast<char>(0x80 | ((code_point >> 6) & 0x3F)));
+    out->push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
+  } else {
+    out->push_back(static_cast<char>(0xF0 | (code_point >> 18)));
+    out->push_back(static_cast<char>(0x80 | ((code_point >> 12) & 0x3F)));
+    out->push_back(static_cast<char>(0x80 | ((code_point >> 6) & 0x3F)));
+    out->push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
+  }
+}
+
+std::string jstring_to_utf8(JNIEnv* env, jstring value) {
   if (!value) return {};
-  const char* chars = env->GetStringUTFChars(value, nullptr);
+  const jsize length = env->GetStringLength(value);
+  const jchar* chars = env->GetStringChars(value, nullptr);
   if (!chars) return {};
-  std::string result(chars);
-  env->ReleaseStringUTFChars(value, chars);
+
+  std::string result;
+  result.reserve(static_cast<size_t>(length) * 3);
+  for (jsize i = 0; i < length; ++i) {
+    const uint32_t first = chars[i];
+    uint32_t code_point = first;
+    if (first >= 0xD800 && first <= 0xDBFF) {
+      if (i + 1 < length) {
+        const uint32_t second = chars[i + 1];
+        if (second >= 0xDC00 && second <= 0xDFFF) {
+          code_point = 0x10000 + ((first - 0xD800) << 10) + (second - 0xDC00);
+          ++i;
+        } else {
+          code_point = kReplacementCharacter;
+        }
+      } else {
+        code_point = kReplacementCharacter;
+      }
+    } else if (first >= 0xDC00 && first <= 0xDFFF) {
+      code_point = kReplacementCharacter;
+    }
+    append_utf8(&result, code_point);
+  }
+  env->ReleaseStringChars(value, chars);
   return result;
+}
+
+bool is_continuation(uint8_t value) {
+  return (value & 0xC0) == 0x80;
+}
+
+uint32_t decode_utf8(const std::string& text, size_t* position) {
+  if (!position || *position >= text.size()) return kReplacementCharacter;
+  const size_t i = *position;
+  const uint8_t b0 = static_cast<uint8_t>(text[i]);
+
+  if (b0 <= 0x7F) {
+    *position = i + 1;
+    return b0;
+  }
+
+  if (b0 >= 0xC2 && b0 <= 0xDF && i + 1 < text.size()) {
+    const uint8_t b1 = static_cast<uint8_t>(text[i + 1]);
+    if (is_continuation(b1)) {
+      *position = i + 2;
+      return ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+    }
+  }
+
+  if (b0 >= 0xE0 && b0 <= 0xEF && i + 2 < text.size()) {
+    const uint8_t b1 = static_cast<uint8_t>(text[i + 1]);
+    const uint8_t b2 = static_cast<uint8_t>(text[i + 2]);
+    const bool second_valid =
+        is_continuation(b1) &&
+        (b0 != 0xE0 || b1 >= 0xA0) &&
+        (b0 != 0xED || b1 <= 0x9F);
+    if (second_valid && is_continuation(b2)) {
+      *position = i + 3;
+      return ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+    }
+  }
+
+  if (b0 >= 0xF0 && b0 <= 0xF4 && i + 3 < text.size()) {
+    const uint8_t b1 = static_cast<uint8_t>(text[i + 1]);
+    const uint8_t b2 = static_cast<uint8_t>(text[i + 2]);
+    const uint8_t b3 = static_cast<uint8_t>(text[i + 3]);
+    const bool second_valid =
+        is_continuation(b1) &&
+        (b0 != 0xF0 || b1 >= 0x90) &&
+        (b0 != 0xF4 || b1 <= 0x8F);
+    if (second_valid && is_continuation(b2) && is_continuation(b3)) {
+      *position = i + 4;
+      return ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) |
+             ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+    }
+  }
+
+  // Invalid or truncated UTF-8: replace one byte and continue so malformed
+  // native text can never escape as a pending JNI exception.
+  *position = i + 1;
+  return kReplacementCharacter;
+}
+
+jstring utf8_to_jstring(JNIEnv* env, const std::string& value) {
+  std::vector<jchar> utf16;
+  utf16.reserve(value.size());
+  size_t position = 0;
+  while (position < value.size()) {
+    uint32_t code_point = decode_utf8(value, &position);
+    if (code_point <= 0xFFFF) {
+      utf16.push_back(static_cast<jchar>(code_point));
+    } else {
+      code_point -= 0x10000;
+      utf16.push_back(static_cast<jchar>(0xD800 + (code_point >> 10)));
+      utf16.push_back(static_cast<jchar>(0xDC00 + (code_point & 0x3FF)));
+    }
+  }
+  const jchar empty = 0;
+  return env->NewString(utf16.empty() ? &empty : utf16.data(),
+                        static_cast<jsize>(utf16.size()));
 }
 
 jobjectArray make_strings(JNIEnv* env, const std::vector<std::string>& values) {
@@ -28,10 +148,16 @@ jobjectArray make_strings(JNIEnv* env, const std::vector<std::string>& values) {
   if (!string_class) return nullptr;
   jobjectArray result = env->NewObjectArray(
       static_cast<jsize>(values.size()), string_class, nullptr);
+  if (!result) {
+    env->DeleteLocalRef(string_class);
+    return nullptr;
+  }
   for (jsize i = 0; i < static_cast<jsize>(values.size()); ++i) {
-    jstring value = env->NewStringUTF(values[static_cast<size_t>(i)].c_str());
+    jstring value = utf8_to_jstring(env, values[static_cast<size_t>(i)]);
+    if (!value) break;
     env->SetObjectArrayElement(result, i, value);
     env->DeleteLocalRef(value);
+    if (env->ExceptionCheck()) break;
   }
   env->DeleteLocalRef(string_class);
   return result;
@@ -78,7 +204,7 @@ std::vector<std::string> snapshot_locked() {
                           context.composition.preedit : "");
 
   // The context menu only exposes the current page (five items in the
-  // bundled default).  Iterate the complete candidate stream so Android's
+  // bundled default). Iterate the complete candidate stream so Android's
   // expandable candidate panel can actually reach uncommon characters and
   // words without changing Rime's ranking.
   bool iterated = false;
@@ -123,8 +249,8 @@ Java_llc_slacker_openime_RimeNative_nativeStartup(
   // Recover from any previous partial initialization before retrying.
   if (g_api || g_initialized) shutdown_locked();
 
-  const std::string shared = jstring_to_string(env, shared_dir);
-  const std::string user = jstring_to_string(env, user_dir);
+  const std::string shared = jstring_to_utf8(env, shared_dir);
+  const std::string user = jstring_to_utf8(env, user_dir);
   setenv("RIME_SHARED_DATA_DIR", shared.c_str(), 1);
   setenv("RIME_USER_DATA_DIR", user.c_str(), 1);
 
@@ -172,7 +298,7 @@ Java_llc_slacker_openime_RimeNative_nativeSetInput(
     JNIEnv* env, jclass, jstring input) {
   std::lock_guard<std::mutex> lock(g_mutex);
   if (!g_api || !g_session || !g_api->set_input) return make_strings(env, {});
-  const std::string value = jstring_to_string(env, input);
+  const std::string value = jstring_to_utf8(env, input);
   g_api->set_input(g_session, value.c_str());
   return make_strings(env, snapshot_locked());
 }
@@ -181,32 +307,29 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_llc_slacker_openime_RimeNative_nativeSelectCandidate(
     JNIEnv* env, jclass, jint index) {
   std::lock_guard<std::mutex> lock(g_mutex);
-  if (!g_api || !g_session || index < 0) return env->NewStringUTF("");
+  if (!g_api || !g_session || index < 0) return utf8_to_jstring(env, "");
   if (!g_api->select_candidate(g_session, static_cast<size_t>(index))) {
-    return env->NewStringUTF("");
+    return utf8_to_jstring(env, "");
   }
-  // Selecting a candidate normally only confirms a Rime segment.  Explicitly
+  // Selecting a candidate normally only confirms a Rime segment. Explicitly
   // commit the completed composition so the chosen word is learned, any
   // remaining segmented input is preserved, and the Android pre-edit can be
   // cleared atomically after the click.
-  const std::string commit = finish_selection();
-  return env->NewStringUTF(commit.c_str());
+  return utf8_to_jstring(env, finish_selection());
 }
 
 extern "C" JNIEXPORT jstring JNICALL
 Java_llc_slacker_openime_RimeNative_nativeCommitFirst(
     JNIEnv* env, jclass) {
   std::lock_guard<std::mutex> lock(g_mutex);
-  if (!g_api || !g_session) return env->NewStringUTF("");
+  if (!g_api || !g_session) return utf8_to_jstring(env, "");
   if (g_api->select_candidate(g_session, 0)) {
-    const std::string commit = finish_selection();
-    return env->NewStringUTF(commit.c_str());
+    return utf8_to_jstring(env, finish_selection());
   }
   if (g_api->commit_composition(g_session)) {
-    const std::string commit = take_commit();
-    return env->NewStringUTF(commit.c_str());
+    return utf8_to_jstring(env, take_commit());
   }
-  return env->NewStringUTF("");
+  return utf8_to_jstring(env, "");
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -221,4 +344,10 @@ Java_llc_slacker_openime_RimeNative_nativeShutdown(
     JNIEnv*, jclass) {
   std::lock_guard<std::mutex> lock(g_mutex);
   shutdown_locked();
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_llc_slacker_openime_RimeNative_nativeUtf8RoundTripForTest(
+    JNIEnv* env, jclass, jstring input) {
+  return utf8_to_jstring(env, jstring_to_utf8(env, input));
 }

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -10,6 +10,9 @@ internal data class RimeCandidateEntry(
     val nativeIndex: Int,
 )
 
+internal fun rimeProbeHasCandidate(snapshot: Array<String>): Boolean =
+    snapshot.drop(2).any { it.isNotBlank() }
+
 /**
  * Tracks ownership of one asynchronous startup attempt. Destroy invalidates the
  * current generation immediately; a stale worker may clean native state, but it
@@ -98,10 +101,17 @@ class RimeEngine(private val context: Context) {
                 }
 
                 synchronized(lock) {
-                    // A session with no candidates is not useful; the native
-                    // side has already completed synchronous deployment here.
-                    val probe = RimeNative.nativeSetInput("")
-                    check(probe.isNotEmpty()) { "librime session unavailable" }
+                    // Prove that the selected schema and translator are actually
+                    // usable. An empty-input snapshot can look non-empty even
+                    // when no schema can produce candidates.
+                    val probe = try {
+                        RimeNative.nativeSetInput(HEALTH_PROBE_INPUT)
+                    } finally {
+                        RimeNative.nativeClear()
+                    }
+                    check(rimeProbeHasCandidate(probe)) {
+                        "librime schema/candidate pipeline unavailable"
+                    }
                 }
                 if (!startupGate.complete(generation)) {
                     cleanupNative()
@@ -238,5 +248,6 @@ class RimeEngine(private val context: Context) {
 
     private companion object {
         const val TAG = "RimeEngine"
+        const val HEALTH_PROBE_INPUT = "ni"
     }
 }

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -1,6 +1,7 @@
 package llc.slacker.openime
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import java.io.File
 import java.util.concurrent.Executors
@@ -13,7 +14,7 @@ internal data class RimeCandidateEntry(
 internal fun rimeProbeHasCandidate(snapshot: Array<String>): Boolean =
     snapshot.drop(2).any { it.isNotBlank() }
 
-internal fun rimeDataRevision(versionCode: Int): String = "apk-$versionCode"
+internal fun rimeDataRevision(versionCode: Long): String = "apk-$versionCode"
 
 /**
  * Tracks ownership of one asynchronous startup attempt. Destroy invalidates the
@@ -219,16 +220,25 @@ class RimeEngine(private val context: Context) {
             .distinctBy { it.text }
 
     private fun copyAssetsIfNeeded(sharedDir: File) {
-        // An APK upgrade necessarily changes versionCode. Tie the copied Rime
-        // data revision to that build identity so asset changes cannot silently
-        // keep an old filesDir copy because somebody forgot to bump a magic
-        // marker number. Re-copying once per app upgrade is cheap and explicit.
-        val revision = rimeDataRevision(BuildConfig.VERSION_CODE)
+        // Read the identity of the actually installed APK instead of relying on
+        // generated BuildConfig fields. This stays valid even when BuildConfig
+        // generation is disabled and automatically changes on every upgrade.
+        val revision = rimeDataRevision(installedVersionCode())
         val marker = File(sharedDir, ".openime-rime-$revision")
         if (marker.exists() && File(sharedDir, "luna_pinyin_simp.schema.yaml").exists()) return
         deleteChildren(sharedDir)
         copyAssetTree("rime-data", sharedDir)
         marker.writeText("openIME Rime data revision $revision\n")
+    }
+
+    @Suppress("DEPRECATION")
+    private fun installedVersionCode(): Long {
+        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.longVersionCode
+        } else {
+            packageInfo.versionCode.toLong()
+        }
     }
 
     private fun copyAssetTree(assetPath: String, destination: File) {

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -11,6 +11,50 @@ internal data class RimeCandidateEntry(
 )
 
 /**
+ * Tracks ownership of one asynchronous startup attempt. Destroy invalidates the
+ * current generation immediately; a stale worker may clean native state, but it
+ * can never publish READY after its owner has gone away.
+ */
+internal class RimeStartupGate {
+    private var generation = 0L
+    private var starting = false
+    private var destroyed = false
+
+    @Synchronized
+    fun begin(): Long? {
+        if (destroyed || starting) return null
+        generation += 1
+        starting = true
+        return generation
+    }
+
+    @Synchronized
+    fun isCurrent(token: Long): Boolean =
+        !destroyed && starting && generation == token
+
+    @Synchronized
+    fun complete(token: Long): Boolean {
+        if (!isCurrent(token)) return false
+        starting = false
+        return true
+    }
+
+    @Synchronized
+    fun fail(token: Long): Boolean {
+        if (!isCurrent(token)) return false
+        starting = false
+        return true
+    }
+
+    @Synchronized
+    fun destroy() {
+        destroyed = true
+        starting = false
+        generation += 1
+    }
+}
+
+/**
  * Owns one process-local librime session and exposes IME-friendly operations.
  *
  * Rime deployment is deliberately done off the IME main thread. A slow first
@@ -20,6 +64,7 @@ internal data class RimeCandidateEntry(
  */
 class RimeEngine(private val context: Context) {
     private val lock = Any()
+    private val startupGate = RimeStartupGate()
     private val startupExecutor = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "local-rime-startup").apply { isDaemon = true }
     }
@@ -32,23 +77,46 @@ class RimeEngine(private val context: Context) {
 
     fun start() {
         if (isReady) return
+        val generation = startupGate.begin() ?: return
         startupExecutor.execute {
-            runCatching {
+            var nativeStartupReturned = false
+            try {
                 val sharedDir = File(context.filesDir, "rime-data").apply { mkdirs() }
                 val userDir = File(context.filesDir, "rime-user").apply { mkdirs() }
+                if (!startupGate.isCurrent(generation)) return@execute
                 copyAssetsIfNeeded(sharedDir)
+                if (!startupGate.isCurrent(generation)) return@execute
+
+                // nativeStartup is internally serialized. Even if destroy races
+                // this call, nativeShutdown will either run after it or this
+                // stale worker will perform the same idempotent cleanup below.
                 RimeNative.nativeStartup(sharedDir.absolutePath, userDir.absolutePath)
+                nativeStartupReturned = true
+                if (!startupGate.isCurrent(generation)) {
+                    cleanupNative()
+                    return@execute
+                }
+
                 synchronized(lock) {
                     // A session with no candidates is not useful; the native
                     // side has already completed synchronous deployment here.
                     val probe = RimeNative.nativeSetInput("")
                     check(probe.isNotEmpty()) { "librime session unavailable" }
                 }
+                if (!startupGate.complete(generation)) {
+                    cleanupNative()
+                    return@execute
+                }
+                errorMessage = ""
                 isReady = true
                 Log.i(TAG, "librime ready")
-            }.onFailure { throwable ->
-                errorMessage = throwable.message ?: throwable.javaClass.simpleName
-                Log.w(TAG, "librime unavailable; keeping Kotlin fallback", throwable)
+            } catch (throwable: Throwable) {
+                if (nativeStartupReturned) cleanupNative()
+                if (startupGate.fail(generation)) {
+                    isReady = false
+                    errorMessage = throwable.message ?: throwable.javaClass.simpleName
+                    Log.w(TAG, "librime unavailable; keeping Kotlin fallback", throwable)
+                }
             }
         }
     }
@@ -117,13 +185,16 @@ class RimeEngine(private val context: Context) {
     }
 
     fun shutdown() {
-        if (isReady) {
-            synchronized(lock) {
-                runCatching { RimeNative.nativeShutdown() }
-            }
-        }
+        startupGate.destroy()
         isReady = false
+        cleanupNative()
         startupExecutor.shutdownNow()
+    }
+
+    private fun cleanupNative() {
+        synchronized(lock) {
+            runCatching { RimeNative.nativeShutdown() }
+        }
     }
 
     private fun snapshotCandidateEntries(snapshot: Array<String>): List<RimeCandidateEntry> =

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -13,6 +13,8 @@ internal data class RimeCandidateEntry(
 internal fun rimeProbeHasCandidate(snapshot: Array<String>): Boolean =
     snapshot.drop(2).any { it.isNotBlank() }
 
+internal fun rimeDataRevision(versionCode: Int): String = "apk-$versionCode"
+
 /**
  * Tracks ownership of one asynchronous startup attempt. Destroy invalidates the
  * current generation immediately; a stale worker may clean native state, but it
@@ -217,11 +219,16 @@ class RimeEngine(private val context: Context) {
             .distinctBy { it.text }
 
     private fun copyAssetsIfNeeded(sharedDir: File) {
-        val marker = File(sharedDir, ".openime-rime-3")
+        // An APK upgrade necessarily changes versionCode. Tie the copied Rime
+        // data revision to that build identity so asset changes cannot silently
+        // keep an old filesDir copy because somebody forgot to bump a magic
+        // marker number. Re-copying once per app upgrade is cheap and explicit.
+        val revision = rimeDataRevision(BuildConfig.VERSION_CODE)
+        val marker = File(sharedDir, ".openime-rime-$revision")
         if (marker.exists() && File(sharedDir, "luna_pinyin_simp.schema.yaml").exists()) return
         deleteChildren(sharedDir)
         copyAssetTree("rime-data", sharedDir)
-        marker.writeText("openIME Rime data revision 3 with Rime Ice core lexicons\n")
+        marker.writeText("openIME Rime data revision $revision\n")
     }
 
     private fun copyAssetTree(assetPath: String, destination: File) {

--- a/app/src/main/java/llc/slacker/openime/RimeNative.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeNative.kt
@@ -23,5 +23,9 @@ internal object RimeNative {
 
     @JvmStatic
     external fun nativeShutdown()
+
+    /** JNI boundary regression hook; does not touch the Rime session. */
+    @JvmStatic
+    external fun nativeUtf8RoundTripForTest(input: String): String
 }
 

--- a/app/src/test/java/llc/slacker/openime/RimeStartupGateTest.kt
+++ b/app/src/test/java/llc/slacker/openime/RimeStartupGateTest.kt
@@ -1,5 +1,6 @@
 package llc.slacker.openime
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -46,5 +47,11 @@ class RimeStartupGateTest {
         assertFalse(rimeProbeHasCandidate(arrayOf("ni", "ni")))
         assertFalse(rimeProbeHasCandidate(arrayOf("ni", "ni", "", "  ")))
         assertTrue(rimeProbeHasCandidate(arrayOf("ni", "ni", "你")))
+    }
+
+    @Test
+    fun rimeDataRevisionTracksApkVersionCode() {
+        assertEquals("apk-1", rimeDataRevision(1))
+        assertEquals("apk-42", rimeDataRevision(42))
     }
 }

--- a/app/src/test/java/llc/slacker/openime/RimeStartupGateTest.kt
+++ b/app/src/test/java/llc/slacker/openime/RimeStartupGateTest.kt
@@ -1,0 +1,42 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RimeStartupGateTest {
+    @Test
+    fun onlyOneStartupCanBeInFlight() {
+        val gate = RimeStartupGate()
+        val first = gate.begin()
+
+        assertNotNull(first)
+        assertNull(gate.begin())
+        assertTrue(gate.isCurrent(first!!))
+    }
+
+    @Test
+    fun failedAttemptCanRetry() {
+        val gate = RimeStartupGate()
+        val first = gate.begin()!!
+
+        assertTrue(gate.fail(first))
+        assertFalse(gate.isCurrent(first))
+        assertNotNull(gate.begin())
+    }
+
+    @Test
+    fun destroyInvalidatesStaleWorkerAndBlocksRestart() {
+        val gate = RimeStartupGate()
+        val first = gate.begin()!!
+
+        gate.destroy()
+
+        assertFalse(gate.isCurrent(first))
+        assertFalse(gate.complete(first))
+        assertFalse(gate.fail(first))
+        assertNull(gate.begin())
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/RimeStartupGateTest.kt
+++ b/app/src/test/java/llc/slacker/openime/RimeStartupGateTest.kt
@@ -39,4 +39,12 @@ class RimeStartupGateTest {
         assertFalse(gate.fail(first))
         assertNull(gate.begin())
     }
+
+    @Test
+    fun healthProbeRequiresCandidateBeyondInputAndPreedit() {
+        assertFalse(rimeProbeHasCandidate(emptyArray()))
+        assertFalse(rimeProbeHasCandidate(arrayOf("ni", "ni")))
+        assertFalse(rimeProbeHasCandidate(arrayOf("ni", "ni", "", "  ")))
+        assertTrue(rimeProbeHasCandidate(arrayOf("ni", "ni", "你")))
+    }
 }


### PR DESCRIPTION
## Summary
- add a startup generation gate so a stale background deployment cannot publish `isReady=true` after the IME service has been destroyed
- make `RimeEngine.shutdown()` invalidate startup ownership before native cleanup
- make native shutdown unconditional and idempotent
- track native `initialize()` separately from session creation so partial initialization is always finalized
- recover from partial native state before a later startup retry
- require successful `luna_pinyin_simp`/`luna_pinyin` schema selection
- replace the empty-input readiness check with a real `ni` candidate health probe and clear it without learning
- replace the hand-maintained `.openime-rime-3` marker with an APK-version-derived Rime data revision so upgrades automatically redeploy copied assets
- replace Modified UTF-8 JNI APIs with explicit standard UTF-8 <-> UTF-16 conversion for Rime input/candidates/commits
- add a JNI instrumentation regression covering CJK Extension B (`𠀀`), emoji, BMP CJK, and accented Latin text
- add JVM tests for startup ownership, retry, destroy invalidation, health-probe semantics, and data revision identity

Closes #11
Closes #19
Closes #21
Closes #22