### PR TITLE
Remove English T9 candidate matching

### DIFF
--- a/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
@@ -118,9 +118,9 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
     }
 
     /**
-     * A compact T9 index. 9-key input must never enumerate every possible
-     * letter combination: 3^50 combinations would freeze the IME main
-     * thread before the user can see the next key feedback.
+     * A compact Chinese 9-key Pinyin index. It must never enumerate every
+     * possible letter combination: 3^50 combinations would freeze the IME
+     * main thread before the user can see the next key feedback.
      */
     private data class NineKeyEntry(
         val pinyin: String,
@@ -486,35 +486,13 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         )
     }
 
-    fun getT9EnglishCandidates(digits: String): List<String> {
-        if (digits.isEmpty()) return emptyList()
-        val wanted = digits.filter { it.isDigit() }.ifEmpty { return emptyList() }
-        val matches = linkedSetOf<String>()
-        val words = ImeData.englishDict.values.flatten() + ImeData.englishDict.keys
-        words.distinct().forEach { word ->
-            if (wordToT9(word) == wanted) {
-                matches.add(word)
-                if (matches.size >= 12) return@forEach
-            }
-        }
-        return matches.toList().ifEmpty { listOf(wanted) }
-    }
-
-    private fun wordToT9(word: String): String {
-        val map = mapOf(
-            "abc" to "2",
-            "def" to "3",
-            "ghi" to "4",
-            "jkl" to "5",
-            "mno" to "6",
-            "pqrs" to "7",
-            "tuv" to "8",
-            "wxyz" to "9",
-        )
-        return word.lowercase().map { ch ->
-            map.entries.firstOrNull { it.key.contains(ch) }?.value ?: ""
-        }.joinToString("")
-    }
+    /**
+     * English T9 was removed from the product. Keep this empty compatibility
+     * surface only while legacy view/state code still references the old mode;
+     * it deliberately performs no dictionary scan or digit-to-word matching.
+     */
+    @Deprecated("English T9 is no longer supported")
+    fun getT9EnglishCandidates(@Suppress("UNUSED_PARAMETER") digits: String): List<String> = emptyList()
 
     private fun lowerBound(values: List<String>, target: String): Int {
         var low = 0

--- a/app/src/test/java/llc/slacker/openime/CandidateEngineTest.kt
+++ b/app/src/test/java/llc/slacker/openime/CandidateEngineTest.kt
@@ -51,12 +51,6 @@ class CandidateEngineTest {
     }
 
     @Test
-    fun t9GoodResolvesToKnownWords() {
-        val result = engine.getT9EnglishCandidates("4663")
-        assertTrue("4663 should include good", result.contains("good"))
-    }
-
-    @Test
     fun fallbackReturnsPinyin() {
         assertEquals(listOf("xyzzy"), engine.getCandidates("xyzzy"))
     }


### PR DESCRIPTION
## Summary
- remove the English T9 digit-to-word matcher and its repeated full-dictionary scan
- keep Chinese Pinyin 9-key (`get9KeyCandidates`) unchanged, including long-stream decoding and segmentation
- leave only an empty deprecated compatibility surface because legacy view/state code still references the old, already-unexposed `ENGLISH_T9` enum
- remove the obsolete English T9 candidate regression while retaining Chinese 9-key stress/regression coverage

The English T9 mode is not exposed by the keyboard selector and `setMode(ENGLISH_T9)` already redirects to Pinyin 26-key. This PR removes the remaining candidate-engine behavior without touching Chinese nine-key input.

Closes #31