### PR TITLE
Collapse selections before text-editor arrow movement

### DIFF
--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -16,6 +16,24 @@ internal fun relativeCursorKeyCode(delta: Int): Int? = when (delta) {
     else -> null
 }
 
+internal fun collapseSelectionForAdjacentArrow(
+    currentStart: Int,
+    currentEnd: Int,
+    requestedStart: Int,
+    requestedEnd: Int,
+): Pair<Int, Int> {
+    if (requestedStart != requestedEnd || currentStart == currentEnd) {
+        return requestedStart to requestedEnd
+    }
+    val left = minOf(currentStart, currentEnd)
+    val right = maxOf(currentStart, currentEnd)
+    return when (requestedStart) {
+        left - 1 -> left to left
+        right + 1 -> right to right
+        else -> requestedStart to requestedEnd
+    }
+}
+
 /**
  * Single funnel for all editor side effects. Password fields are never logged,
  * uploaded or added to history; direct typing is still forwarded to the editor.
@@ -151,14 +169,25 @@ class InputConnectionGateway(
      * editor exposes only a bounded before/after window, a one-character move
      * is delegated back to the editor through DPAD instead of fabricating an
      * absolute document coordinate from that local window.
+     *
+     * The text-editor panel currently expresses left/right movement as one
+     * position beyond the current edge. With a non-empty selection Android's
+     * normal arrow semantics collapse to that edge first, so intercept exactly
+     * those adjacent requests instead of moving one extra character.
      */
     fun selectStartEnd(start: Int, end: Int) {
         if (isPassword()) return
         val ic = connection() ?: return
         when (val selection = selectionSnapshot(ic)) {
             is SelectionSnapshot.Absolute -> {
-                val safeStart = start.coerceAtLeast(0)
-                val safeEnd = end.coerceAtLeast(safeStart)
+                val (targetStart, targetEnd) = collapseSelectionForAdjacentArrow(
+                    currentStart = selection.start,
+                    currentEnd = selection.end,
+                    requestedStart = start,
+                    requestedEnd = end,
+                )
+                val safeStart = targetStart.coerceAtLeast(0)
+                val safeEnd = targetEnd.coerceAtLeast(safeStart)
                 ic.setSelection(safeStart, safeEnd)
             }
             is SelectionSnapshot.Relative -> {

--- a/app/src/test/java/llc/slacker/openime/SelectionArrowPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/SelectionArrowPolicyTest.kt
@@ -1,0 +1,58 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SelectionArrowPolicyTest {
+    @Test
+    fun leftArrowCollapsesSelectionAtLeftEdge() {
+        assertEquals(
+            2 to 2,
+            collapseSelectionForAdjacentArrow(
+                currentStart = 2,
+                currentEnd = 5,
+                requestedStart = 1,
+                requestedEnd = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun rightArrowCollapsesSelectionAtRightEdge() {
+        assertEquals(
+            5 to 5,
+            collapseSelectionForAdjacentArrow(
+                currentStart = 2,
+                currentEnd = 5,
+                requestedStart = 6,
+                requestedEnd = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun collapsedCursorStillMovesNormally() {
+        assertEquals(
+            2 to 2,
+            collapseSelectionForAdjacentArrow(
+                currentStart = 3,
+                currentEnd = 3,
+                requestedStart = 2,
+                requestedEnd = 2,
+            ),
+        )
+    }
+
+    @Test
+    fun explicitSelectionRequestIsNotRewritten() {
+        assertEquals(
+            1 to 4,
+            collapseSelectionForAdjacentArrow(
+                currentStart = 2,
+                currentEnd = 5,
+                requestedStart = 1,
+                requestedEnd = 4,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- preserve Android arrow semantics when the text-editor panel moves across an active selection
- intercept only the existing one-position-beyond-edge arrow request pattern
- collapse left to the selection's left edge and right to its right edge instead of moving one extra character
- keep collapsed-cursor movement and ordinary explicit selection requests unchanged
- add pure JVM regression coverage for left/right collapse and unaffected cases

Closes #25