### PR TITLE
Fix Unicode-safe backspace on supplementary characters

### DIFF
--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -88,7 +88,12 @@ class InputConnectionGateway(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             ic.deleteSurroundingTextInCodePoints(1, 0)
         } else {
-            ic.deleteSurroundingText(1, 0)
+            // API 26/27 only exposes UTF-16-unit deletion. Inspect the two
+            // units before the cursor so one backspace never leaves half of a
+            // supplementary code point (emoji / extension Han) behind.
+            val before = runCatching { ic.getTextBeforeCursor(2, 0) }.getOrNull()
+            val utf16Units = previousCodePointUtf16Length(before).coerceAtLeast(1)
+            ic.deleteSurroundingText(utf16Units, 0)
         }
     }
 

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -1036,14 +1036,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         VoiceCorrectionRepository.record(pending.original, corrected)
     }
 
-    private fun dropLastCodePoint(text: String): String {
-        if (text.isEmpty()) return text
-        val last = text.last()
-        if (Character.isHighSurrogate(last) && text.length >= 2 && Character.isLowSurrogate(text[text.length - 2])) {
-            return text.substring(0, text.length - 2)
-        }
-        return text.substring(0, text.length - 1)
-    }
+    private fun dropLastCodePoint(text: String): String = dropLastCodePointSafe(text)
 
     /**
      * The floating keyboard is an actual IME window, not a card translated

--- a/app/src/main/java/llc/slacker/openime/UnicodeText.kt
+++ b/app/src/main/java/llc/slacker/openime/UnicodeText.kt
@@ -1,0 +1,28 @@
+package llc.slacker.openime
+
+/**
+ * Unicode helpers shared by composition editing and pre-Android-9 editor deletion.
+ * Android's legacy deleteSurroundingText() counts UTF-16 code units, while users
+ * expect one backspace to remove one Unicode code point.
+ */
+internal fun dropLastCodePointSafe(text: String): String {
+    if (text.isEmpty()) return text
+    val units = previousCodePointUtf16Length(text).coerceAtLeast(1)
+    return text.substring(0, text.length - units)
+}
+
+/** Return the UTF-16 width of the final complete code point in [text]. */
+internal fun previousCodePointUtf16Length(text: CharSequence?): Int {
+    if (text.isNullOrEmpty()) return 0
+    val lastIndex = text.length - 1
+    val last = text[lastIndex]
+    return if (
+        Character.isLowSurrogate(last) &&
+        lastIndex > 0 &&
+        Character.isHighSurrogate(text[lastIndex - 1])
+    ) {
+        2
+    } else {
+        1
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/UnicodeTextTest.kt
+++ b/app/src/test/java/llc/slacker/openime/UnicodeTextTest.kt
@@ -1,0 +1,38 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UnicodeTextTest {
+
+    @Test
+    fun dropsBmpCharacterAsOneUtf16Unit() {
+        assertEquals("ab", dropLastCodePointSafe("abc"))
+        assertEquals(1, previousCodePointUtf16Length("abc"))
+    }
+
+    @Test
+    fun dropsEmojiSurrogatePairAsOneCodePoint() {
+        assertEquals("a", dropLastCodePointSafe("a😀"))
+        assertEquals(2, previousCodePointUtf16Length("a😀"))
+    }
+
+    @Test
+    fun dropsSupplementaryHanAsOneCodePoint() {
+        assertEquals("汉", dropLastCodePointSafe("汉𠀀"))
+        assertEquals(2, previousCodePointUtf16Length("汉𠀀"))
+    }
+
+    @Test
+    fun isolatedSurrogateDoesNotConsumeNeighbor() {
+        assertEquals("a", dropLastCodePointSafe("a\uDC00"))
+        assertEquals(1, previousCodePointUtf16Length("a\uDC00"))
+    }
+
+    @Test
+    fun emptyTextHasNoPreviousCodePoint() {
+        assertEquals("", dropLastCodePointSafe(""))
+        assertEquals(0, previousCodePointUtf16Length(""))
+        assertEquals(0, previousCodePointUtf16Length(null))
+    }
+}


### PR DESCRIPTION
## Summary
- fix composition backspace so UTF-16 surrogate pairs are removed as one Unicode code point
- make the API 26/27 `deleteSurroundingText` fallback inspect the previous two UTF-16 units and delete 2 units for a valid surrogate pair
- share the code-point width logic between composition and editor deletion
- add pure JVM regression coverage for BMP text, 😀, U+20000 extension Han, isolated surrogates, and empty input

Closes #27