### PR TITLE
Respect IME_FLAG_NO_ENTER_ACTION for Enter

### DIFF
--- a/app/src/main/java/llc/slacker/openime/EnterActionPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/EnterActionPolicy.kt
@@ -1,0 +1,18 @@
+package llc.slacker.openime
+
+import android.view.inputmethod.EditorInfo
+
+/** Resolve an editor action for an Enter press, or null when a real Enter is required. */
+internal fun editorActionForEnter(imeOptions: Int): Int? {
+    if ((imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION) != 0) return null
+    val action = imeOptions and EditorInfo.IME_MASK_ACTION
+    return when (action) {
+        EditorInfo.IME_ACTION_GO,
+        EditorInfo.IME_ACTION_SEARCH,
+        EditorInfo.IME_ACTION_SEND,
+        EditorInfo.IME_ACTION_NEXT,
+        EditorInfo.IME_ACTION_DONE,
+        -> action
+        else -> null
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -562,15 +562,11 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             return
         }
         finalizeVoiceCorrectionIfNeeded()
-        val action = state.editorAction
-        when (action) {
-            EditorInfo.IME_ACTION_GO,
-            EditorInfo.IME_ACTION_SEARCH,
-            EditorInfo.IME_ACTION_SEND,
-            EditorInfo.IME_ACTION_NEXT,
-            EditorInfo.IME_ACTION_DONE,
-            -> gateway.performEditorAction(action)
-            else -> gateway.sendKeyDownUp(KeyEvent.KEYCODE_ENTER)
+        val action = state.editorInfo?.imeOptions?.let(::editorActionForEnter)
+        if (action != null) {
+            gateway.performEditorAction(action)
+        } else {
+            gateway.sendKeyDownUp(KeyEvent.KEYCODE_ENTER)
         }
     }
 

--- a/app/src/test/java/llc/slacker/openime/EnterActionPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/EnterActionPolicyTest.kt
@@ -1,0 +1,40 @@
+package llc.slacker.openime
+
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EnterActionPolicyTest {
+
+    @Test
+    fun noEnterActionForcesRealEnterInsteadOfSend() {
+        val options = EditorInfo.IME_ACTION_SEND or EditorInfo.IME_FLAG_NO_ENTER_ACTION
+        assertNull(editorActionForEnter(options))
+    }
+
+    @Test
+    fun noEnterActionForcesRealEnterInsteadOfDone() {
+        val options = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_ENTER_ACTION
+        assertNull(editorActionForEnter(options))
+    }
+
+    @Test
+    fun explicitSingleLineActionsRemainActions() {
+        assertEquals(EditorInfo.IME_ACTION_SEND, editorActionForEnter(EditorInfo.IME_ACTION_SEND))
+        assertEquals(EditorInfo.IME_ACTION_DONE, editorActionForEnter(EditorInfo.IME_ACTION_DONE))
+        assertEquals(EditorInfo.IME_ACTION_SEARCH, editorActionForEnter(EditorInfo.IME_ACTION_SEARCH))
+    }
+
+    @Test
+    fun unrelatedImeFlagsDoNotSuppressAction() {
+        val options = EditorInfo.IME_ACTION_SEARCH or EditorInfo.IME_FLAG_NO_EXTRACT_UI
+        assertEquals(EditorInfo.IME_ACTION_SEARCH, editorActionForEnter(options))
+    }
+
+    @Test
+    fun noActionFallsBackToRealEnter() {
+        assertNull(editorActionForEnter(EditorInfo.IME_ACTION_NONE))
+        assertNull(editorActionForEnter(EditorInfo.IME_ACTION_UNSPECIFIED))
+    }
+}


### PR DESCRIPTION
## Summary
- evaluate Enter behavior from the full `EditorInfo.imeOptions` instead of the masked action alone
- honor `IME_FLAG_NO_ENTER_ACTION` by sending a real Enter key rather than triggering SEND/DONE/GO/etc.
- preserve the existing explicit GO/SEARCH/SEND/NEXT/DONE action behavior when the flag is absent
- add JVM regression tests for NO_ENTER_ACTION, normal single-line actions, unrelated flags, and no-action cases

Closes #26