### PR TITLE
Clear stale composition on external selection changes

### DIFF
--- a/app/src/androidTest/java/llc/slacker/openime/SelectionUpdatePolicyInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/SelectionUpdatePolicyInstrumentedTest.kt
@@ -1,0 +1,41 @@
+package llc.slacker.openime
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SelectionUpdatePolicyInstrumentedTest {
+
+    @Test
+    fun externalCursorMoveInvalidatesActiveComposition() {
+        assertTrue(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 7,
+                oldSelEnd = 7,
+                newSelStart = 20,
+                newSelEnd = 20,
+                candidatesStart = 5,
+                candidatesEnd = 7,
+            ),
+        )
+    }
+
+    @Test
+    fun imeComposingSelectionUpdateIsKept() {
+        assertFalse(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 5,
+                oldSelEnd = 5,
+                newSelStart = 7,
+                newSelEnd = 7,
+                candidatesStart = 5,
+                candidatesEnd = 7,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -303,6 +303,10 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 false
             } else {
                 VoicePerformanceTrace.abandon()
+                // Emulator audio is nondeterministic. Feed a deterministic
+                // result through the exact same composing/final callbacks as
+                // the local recognizer while the real long-press UI is tested
+                // separately by voice-press/voice-release.
                 onVoiceSessionStarted(autoCommitOnFinal = true)
                 onVoicePartial(text)
                 onVoiceFinal(text)
@@ -370,12 +374,18 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     internal fun currentMode(): KeyboardMode = state.keyboardMode
+
     internal fun isVoiceActive(): Boolean = keyboardView?.isVoiceActive() == true
+
     internal fun isRimeReadyForTest(): Boolean = ::rime.isInitialized && rime.isReady
+
     internal fun compositionLengthForTest(): Int = lastComposition.length
+
     internal fun voiceComposingForTest(): Boolean = voiceComposing
     internal fun voiceModelStateForTest(): VoiceModelLifecycleState = voiceModelState()
+
     internal fun editorTextLengthForTest(): Int = gateway.currentTextLength()
+
     internal fun candidateDiagnosticsForTest(): String = candidateDiagnostics.asLogFields()
 
     override fun onModeChanged(mode: KeyboardMode) {
@@ -411,6 +421,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             val immediate = immediateCandidates(next, fallback)
             updateComposition(next, immediate)
             requestNativeCandidates(next, state.keyboardMode, fallback)
+            // The view normally updates itself before this callback. If the
+            // visible pre-edit field lost focus, however, the service owns the
+            // deletion and must also remove stale candidate chips.
             keyboardView?.renderState(state)
         } else {
             gateway.deleteBackwards()
@@ -419,6 +432,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     override fun onClearAll() {
+        // Invalidate every pending candidate/Rime path before touching the
+        // editor. Otherwise a late native result can restore the just-cleared
+        // pre-edit on the very next key press.
         clearImeCompositionState(render = false)
         gateway.clearAllText()
         pendingVoiceCorrection = null
@@ -629,11 +645,19 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             return
         }
         val modeAtRequest = state.keyboardMode
+        // The view has already produced the bounded local result for this
+        // key event. Reusing it avoids running the same dictionary work a
+        // second time on the IME main thread during rapid 9-key input.
         val fallback = candidates.ifEmpty {
             fallbackCandidatesFor(composition, modeAtRequest)
         }
         val immediate = immediateCandidates(composition, fallback)
-        updateComposition(composition, immediate)
+        updateComposition(
+            composition,
+            immediate,
+        )
+        // The view renders a fast local result first, then receives the
+        // authoritative librime ordering in the same callback.
         keyboardView?.renderState(state)
         requestNativeCandidates(composition, modeAtRequest, fallback, rimeInputs)
     }
@@ -737,7 +761,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 val end = gateway.currentSelectionEnd()
                 gateway.selectStartEnd(end + 1, end + 1)
             }
-            "up", "down", "undo" -> Unit
+            "up", "down", "undo" -> {
+                // These depend on the target editor; no fake implementation here.
+            }
         }
     }
 
@@ -752,12 +778,20 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         lastComposition = next
         state = state.copy(composition = next, candidates = candidates)
         if (next.isEmpty()) {
+            // Finishing a non-empty composing span preserves it as committed
+            // editor text in many apps. Deleting the final Pinyin character
+            // must remove that span instead of leaving a raw letter behind.
             gateway.cancelComposing()
         } else {
             gateway.setComposingText(next)
         }
     }
 
+    /**
+     * Finish a pending composing string before inserting a non-composing item.
+     * This is what makes punctuation, emoji, symbols and mode changes behave
+     * like a normal IME instead of concatenating the next key into raw pinyin.
+     */
     private fun commitPendingComposition() {
         if (lastComposition.isEmpty()) return
         commitFirstCandidate()
@@ -765,7 +799,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun fallbackCandidatesFor(composition: String, mode: KeyboardMode): List<String> = when (mode) {
         KeyboardMode.ENGLISH_26 -> engine.getEnglishCompletions(composition)
-        KeyboardMode.PINYIN_26 -> engine.getCandidates(composition, state.fuzzyPinyinEnabled)
+        KeyboardMode.PINYIN_26,
+        -> engine.getCandidates(composition, state.fuzzyPinyinEnabled)
         KeyboardMode.PINYIN_9 -> if (composition.length <= 32) {
             engine.getCandidates(composition, state.fuzzyPinyinEnabled)
         } else {
@@ -775,6 +810,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         else -> emptyList()
     }
 
+    /** The extra learner is only a repeated-choice fallback while Rime is unavailable. */
     private fun immediateCandidates(composition: String, fallback: List<String>): List<String> {
         val learned = if (!rime.isReady) {
             UserPhraseRepository.candidatesFor(composition)
@@ -793,6 +829,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         return (learned + fallback).distinct().take(MAX_CANDIDATES)
     }
 
+    /** Query librime away from the IME input thread; stale answers are ignored. */
     private fun requestNativeCandidates(
         composition: String,
         mode: KeyboardMode,
@@ -822,6 +859,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             return
         }
         candidateExecutor.execute {
+            // Coalesce a burst of key events before entering librime. Older
+            // requests are already obsolete and must not build a native queue.
             if (candidateGeneration.get() != request) return@execute
             val query = queryNativeChoices(queryInputs) {
                 candidateGeneration.get() != request
@@ -834,6 +873,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                     lastComposition != composition ||
                     activeRimeInputs != queryInputs
                 ) return@post
+                // Once Rime returns candidates, its mature dictionary and
+                // userdb ordering replace the transient Kotlin preview. The
+                // fallback is retained only when native has no answer.
                 val learned = if (!rime.isReady && native.isEmpty()) {
                     UserPhraseRepository.candidatesFor(composition)
                 } else {
@@ -886,6 +928,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         )
     }
 
+    /** Commit the authoritative first choice, even if the UI still shows the fast fallback. */
     private fun commitFirstCandidate() {
         val composition = lastComposition
         if (composition.isEmpty()) return
@@ -929,7 +972,10 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         val nativeCommit = if (
             composition.length <= MAX_RIME_INPUT_LENGTH &&
             rime.isReady &&
-            (mode == KeyboardMode.PINYIN_26 || mode == KeyboardMode.PINYIN_9)
+            (
+                mode == KeyboardMode.PINYIN_26 ||
+                    mode == KeyboardMode.PINYIN_9
+                )
         ) {
             if (reference != null) {
                 rime.selectCandidate(reference.input, reference.nativeIndex)
@@ -953,6 +999,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun finishCandidateCommit(composition: String, committed: String) {
         if (committed.isEmpty()) return
+        // librime owns normal learning through its userdb. Keep the old local
+        // repository only as an offline fallback; never run two unconditional
+        // ranking systems over the same successful native selection.
         if (!rime.isReady) UserPhraseRepository.record(composition, committed)
         gateway.commitText(committed)
         gateway.finishComposing()
@@ -1001,6 +1050,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun noteVoiceReplacementInput() {
         val pending = pendingVoiceCorrection ?: return
+        // Typing at the end without first deleting any part of the ASR result
+        // is ordinary continuation, not a correction pair.
         if (!pending.edited) pendingVoiceCorrection = null
     }
 
@@ -1018,6 +1069,11 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun dropLastCodePoint(text: String): String = dropLastCodePointSafe(text)
 
+    /**
+     * The floating keyboard is an actual IME window, not a card translated
+     * inside the 296dp keyboard view.  That keeps it draggable over the whole
+     * display while retaining the system IME token and editor connection.
+     */
     private fun scheduleFloatingWindowLayout(resetPosition: Boolean) {
         mainHandler.post {
             val imeWindow = getWindow().window ?: return@post
@@ -1054,7 +1110,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         val (screenWidth, screenHeight) = displaySize()
         val attrs = imeWindow.attributes
         val width = if (attrs.width > 0) attrs.width else minOf(dp(600), screenWidth - dp(10))
-        val height = imeWindow.decorView.height.takeIf { it > 0 } ?: dp(296)
+        val height = (imeWindow.decorView.height.takeIf { it > 0 } ?: dp(296))
         floatingWindowX = floatingWindowX.coerceIn(0, (screenWidth - width).coerceAtLeast(0))
         floatingWindowY = floatingWindowY.coerceIn(0, (screenHeight - height).coerceAtLeast(0))
         attrs.gravity = Gravity.TOP or Gravity.START

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -216,6 +216,41 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         super.onFinishInputView(finishingInput)
     }
 
+    override fun onUpdateSelection(
+        oldSelStart: Int,
+        oldSelEnd: Int,
+        newSelStart: Int,
+        newSelEnd: Int,
+        candidatesStart: Int,
+        candidatesEnd: Int,
+    ) {
+        super.onUpdateSelection(
+            oldSelStart,
+            oldSelEnd,
+            newSelStart,
+            newSelEnd,
+            candidatesStart,
+            candidatesEnd,
+        )
+        if (!shouldClearCompositionForSelectionUpdate(
+                hasComposition = lastComposition.isNotEmpty(),
+                oldSelStart = oldSelStart,
+                oldSelEnd = oldSelEnd,
+                newSelStart = newSelStart,
+                newSelEnd = newSelEnd,
+                candidatesStart = candidatesStart,
+                candidatesEnd = candidatesEnd,
+            )
+        ) return
+
+        // Drop IME-side state before touching the editor so any callback caused
+        // by cancelComposing() observes an already-empty composition and cannot
+        // recursively invalidate a new one.
+        clearImeCompositionState(render = false)
+        gateway.cancelComposing()
+        keyboardView?.renderState(state)
+    }
+
     override fun onDestroy() {
         mainHandler.removeCallbacksAndMessages(null)
         candidateExecutor.shutdownNow()
@@ -268,10 +303,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 false
             } else {
                 VoicePerformanceTrace.abandon()
-                // Emulator audio is nondeterministic. Feed a deterministic
-                // result through the exact same composing/final callbacks as
-                // the local recognizer while the real long-press UI is tested
-                // separately by voice-press/voice-release.
                 onVoiceSessionStarted(autoCommitOnFinal = true)
                 onVoicePartial(text)
                 onVoiceFinal(text)
@@ -339,18 +370,12 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     internal fun currentMode(): KeyboardMode = state.keyboardMode
-
     internal fun isVoiceActive(): Boolean = keyboardView?.isVoiceActive() == true
-
     internal fun isRimeReadyForTest(): Boolean = ::rime.isInitialized && rime.isReady
-
     internal fun compositionLengthForTest(): Int = lastComposition.length
-
     internal fun voiceComposingForTest(): Boolean = voiceComposing
     internal fun voiceModelStateForTest(): VoiceModelLifecycleState = voiceModelState()
-
     internal fun editorTextLengthForTest(): Int = gateway.currentTextLength()
-
     internal fun candidateDiagnosticsForTest(): String = candidateDiagnostics.asLogFields()
 
     override fun onModeChanged(mode: KeyboardMode) {
@@ -386,9 +411,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             val immediate = immediateCandidates(next, fallback)
             updateComposition(next, immediate)
             requestNativeCandidates(next, state.keyboardMode, fallback)
-            // The view normally updates itself before this callback. If the
-            // visible pre-edit field lost focus, however, the service owns the
-            // deletion and must also remove stale candidate chips.
             keyboardView?.renderState(state)
         } else {
             gateway.deleteBackwards()
@@ -397,9 +419,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     override fun onClearAll() {
-        // Invalidate every pending candidate/Rime path before touching the
-        // editor. Otherwise a late native result can restore the just-cleared
-        // pre-edit on the very next key press.
         clearImeCompositionState(render = false)
         gateway.clearAllText()
         pendingVoiceCorrection = null
@@ -610,19 +629,11 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             return
         }
         val modeAtRequest = state.keyboardMode
-        // The view has already produced the bounded local result for this
-        // key event. Reusing it avoids running the same dictionary work a
-        // second time on the IME main thread during rapid 9-key input.
         val fallback = candidates.ifEmpty {
             fallbackCandidatesFor(composition, modeAtRequest)
         }
         val immediate = immediateCandidates(composition, fallback)
-        updateComposition(
-            composition,
-            immediate,
-        )
-        // The view renders a fast local result first, then receives the
-        // authoritative librime ordering in the same callback.
+        updateComposition(composition, immediate)
         keyboardView?.renderState(state)
         requestNativeCandidates(composition, modeAtRequest, fallback, rimeInputs)
     }
@@ -726,9 +737,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 val end = gateway.currentSelectionEnd()
                 gateway.selectStartEnd(end + 1, end + 1)
             }
-            "up", "down", "undo" -> {
-                // These depend on the target editor; no fake implementation here.
-            }
+            "up", "down", "undo" -> Unit
         }
     }
 
@@ -743,20 +752,12 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         lastComposition = next
         state = state.copy(composition = next, candidates = candidates)
         if (next.isEmpty()) {
-            // Finishing a non-empty composing span preserves it as committed
-            // editor text in many apps. Deleting the final Pinyin character
-            // must remove that span instead of leaving a raw letter behind.
             gateway.cancelComposing()
         } else {
             gateway.setComposingText(next)
         }
     }
 
-    /**
-     * Finish a pending composing string before inserting a non-composing item.
-     * This is what makes punctuation, emoji, symbols and mode changes behave
-     * like a normal IME instead of concatenating the next key into raw pinyin.
-     */
     private fun commitPendingComposition() {
         if (lastComposition.isEmpty()) return
         commitFirstCandidate()
@@ -764,8 +765,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun fallbackCandidatesFor(composition: String, mode: KeyboardMode): List<String> = when (mode) {
         KeyboardMode.ENGLISH_26 -> engine.getEnglishCompletions(composition)
-        KeyboardMode.PINYIN_26,
-        -> engine.getCandidates(composition, state.fuzzyPinyinEnabled)
+        KeyboardMode.PINYIN_26 -> engine.getCandidates(composition, state.fuzzyPinyinEnabled)
         KeyboardMode.PINYIN_9 -> if (composition.length <= 32) {
             engine.getCandidates(composition, state.fuzzyPinyinEnabled)
         } else {
@@ -775,7 +775,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         else -> emptyList()
     }
 
-    /** The extra learner is only a repeated-choice fallback while Rime is unavailable. */
     private fun immediateCandidates(composition: String, fallback: List<String>): List<String> {
         val learned = if (!rime.isReady) {
             UserPhraseRepository.candidatesFor(composition)
@@ -794,7 +793,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         return (learned + fallback).distinct().take(MAX_CANDIDATES)
     }
 
-    /** Query librime away from the IME input thread; stale answers are ignored. */
     private fun requestNativeCandidates(
         composition: String,
         mode: KeyboardMode,
@@ -824,8 +822,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             return
         }
         candidateExecutor.execute {
-            // Coalesce a burst of key events before entering librime. Older
-            // requests are already obsolete and must not build a native queue.
             if (candidateGeneration.get() != request) return@execute
             val query = queryNativeChoices(queryInputs) {
                 candidateGeneration.get() != request
@@ -838,9 +834,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                     lastComposition != composition ||
                     activeRimeInputs != queryInputs
                 ) return@post
-                // Once Rime returns candidates, its mature dictionary and
-                // userdb ordering replace the transient Kotlin preview. The
-                // fallback is retained only when native has no answer.
                 val learned = if (!rime.isReady && native.isEmpty()) {
                     UserPhraseRepository.candidatesFor(composition)
                 } else {
@@ -893,7 +886,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         )
     }
 
-    /** Commit the authoritative first choice, even if the UI still shows the fast fallback. */
     private fun commitFirstCandidate() {
         val composition = lastComposition
         if (composition.isEmpty()) return
@@ -937,10 +929,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         val nativeCommit = if (
             composition.length <= MAX_RIME_INPUT_LENGTH &&
             rime.isReady &&
-            (
-                mode == KeyboardMode.PINYIN_26 ||
-                    mode == KeyboardMode.PINYIN_9
-                )
+            (mode == KeyboardMode.PINYIN_26 || mode == KeyboardMode.PINYIN_9)
         ) {
             if (reference != null) {
                 rime.selectCandidate(reference.input, reference.nativeIndex)
@@ -964,9 +953,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun finishCandidateCommit(composition: String, committed: String) {
         if (committed.isEmpty()) return
-        // librime owns normal learning through its userdb. Keep the old local
-        // repository only as an offline fallback; never run two unconditional
-        // ranking systems over the same successful native selection.
         if (!rime.isReady) UserPhraseRepository.record(composition, committed)
         gateway.commitText(committed)
         gateway.finishComposing()
@@ -1015,8 +1001,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun noteVoiceReplacementInput() {
         val pending = pendingVoiceCorrection ?: return
-        // Typing at the end without first deleting any part of the ASR result
-        // is ordinary continuation, not a correction pair.
         if (!pending.edited) pendingVoiceCorrection = null
     }
 
@@ -1034,11 +1018,6 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun dropLastCodePoint(text: String): String = dropLastCodePointSafe(text)
 
-    /**
-     * The floating keyboard is an actual IME window, not a card translated
-     * inside the 296dp keyboard view.  That keeps it draggable over the whole
-     * display while retaining the system IME token and editor connection.
-     */
     private fun scheduleFloatingWindowLayout(resetPosition: Boolean) {
         mainHandler.post {
             val imeWindow = getWindow().window ?: return@post
@@ -1075,7 +1054,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         val (screenWidth, screenHeight) = displaySize()
         val attrs = imeWindow.attributes
         val width = if (attrs.width > 0) attrs.width else minOf(dp(600), screenWidth - dp(10))
-        val height = (imeWindow.decorView.height.takeIf { it > 0 } ?: dp(296))
+        val height = imeWindow.decorView.height.takeIf { it > 0 } ?: dp(296)
         floatingWindowX = floatingWindowX.coerceIn(0, (screenWidth - width).coerceAtLeast(0))
         floatingWindowY = floatingWindowY.coerceIn(0, (screenHeight - height).coerceAtLeast(0))
         attrs.gravity = Gravity.TOP or Gravity.START

--- a/app/src/main/java/llc/slacker/openime/SelectionUpdatePolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/SelectionUpdatePolicy.kt
@@ -1,0 +1,32 @@
+package llc.slacker.openime
+
+/**
+ * Decide whether a host/editor selection callback invalidates the IME's
+ * current pre-edit composition.
+ *
+ * Android reports the active composing range through candidatesStart/end.
+ * Selection changes that stay inside that range are normal composing/cursor
+ * updates. Moving outside it means the editor/user has taken ownership of the
+ * cursor and the old IME composition must not survive at the new position.
+ */
+internal fun shouldClearCompositionForSelectionUpdate(
+    hasComposition: Boolean,
+    oldSelStart: Int,
+    oldSelEnd: Int,
+    newSelStart: Int,
+    newSelEnd: Int,
+    candidatesStart: Int,
+    candidatesEnd: Int,
+): Boolean {
+    if (!hasComposition) return false
+    if (newSelStart < 0 || newSelEnd < 0) return false
+
+    val selectionChanged = oldSelStart != newSelStart || oldSelEnd != newSelEnd
+    if (!selectionChanged) return false
+
+    if (candidatesStart < 0 || candidatesEnd < 0) return true
+    val composingStart = minOf(candidatesStart, candidatesEnd)
+    val composingEnd = maxOf(candidatesStart, candidatesEnd)
+    return newSelStart !in composingStart..composingEnd ||
+        newSelEnd !in composingStart..composingEnd
+}

--- a/app/src/test/java/llc/slacker/openime/SelectionUpdatePolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/SelectionUpdatePolicyTest.kt
@@ -1,0 +1,113 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelectionUpdatePolicyTest {
+
+    @Test
+    fun composingCallbackAtEndDoesNotClear() {
+        assertFalse(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 10,
+                oldSelEnd = 10,
+                newSelStart = 12,
+                newSelEnd = 12,
+                candidatesStart = 10,
+                candidatesEnd = 12,
+            ),
+        )
+    }
+
+    @Test
+    fun movingInsideComposingRangeDoesNotClear() {
+        assertFalse(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 11,
+                newSelEnd = 11,
+                candidatesStart = 10,
+                candidatesEnd = 12,
+            ),
+        )
+    }
+
+    @Test
+    fun clickOutsideComposingRangeClears() {
+        assertTrue(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 30,
+                newSelEnd = 30,
+                candidatesStart = 10,
+                candidatesEnd = 12,
+            ),
+        )
+    }
+
+    @Test
+    fun externalSelectionRangeClears() {
+        assertTrue(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 4,
+                newSelEnd = 8,
+                candidatesStart = 10,
+                candidatesEnd = 12,
+            ),
+        )
+    }
+
+    @Test
+    fun changedSelectionWithoutReportedComposingRangeClears() {
+        assertTrue(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 20,
+                newSelEnd = 20,
+                candidatesStart = -1,
+                candidatesEnd = -1,
+            ),
+        )
+    }
+
+    @Test
+    fun noActiveCompositionNeverClears() {
+        assertFalse(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = false,
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 20,
+                newSelEnd = 20,
+                candidatesStart = -1,
+                candidatesEnd = -1,
+            ),
+        )
+    }
+
+    @Test
+    fun duplicateSelectionCallbackDoesNotClear() {
+        assertFalse(
+            shouldClearCompositionForSelectionUpdate(
+                hasComposition = true,
+                oldSelStart = 12,
+                oldSelEnd = 12,
+                newSelStart = 12,
+                newSelEnd = 12,
+                candidatesStart = -1,
+                candidatesEnd = -1,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- implement `InputMethodService.onUpdateSelection()` in `LocalVoiceImeService`
- keep normal IME composing callbacks when the new selection remains inside the reported composing range
- invalidate candidate generation, Rime/native references, IME composition state, and visible candidates when the host/user moves selection outside the active composing range
- cancel the editor-side composing span only after IME-side state is cleared, preventing recursive stale callbacks
- add JVM policy coverage plus Android-runner coverage for external cursor moves and normal composing updates

Closes #4