### PR TITLE
Commit only the currently rendered candidate snapshot

### DIFF
--- a/app/src/main/java/llc/slacker/openime/CandidateSnapshot.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateSnapshot.kt
@@ -22,12 +22,20 @@ internal data class CandidateSnapshot(
     val visibleCandidates: List<String>
         get() = entries.map { it.text }
 
+    /**
+     * Space/enter commit the rendered first candidate. When there is no
+     * candidate chip, the visible pre-edit string itself remains the commit
+     * target, matching the existing raw-composition fallback.
+     */
     fun firstForCommit(
         currentGeneration: Long,
         currentComposition: String,
         currentMode: KeyboardMode,
-    ): CandidateSnapshotEntry? =
-        if (matches(currentGeneration, currentComposition, currentMode)) entries.firstOrNull() else null
+    ): CandidateSnapshotEntry? {
+        if (!matches(currentGeneration, currentComposition, currentMode)) return null
+        return entries.firstOrNull()
+            ?: composition.takeIf { it.isNotEmpty() }?.let(::CandidateSnapshotEntry)
+    }
 
     fun candidateForCommit(
         candidate: String,

--- a/app/src/main/java/llc/slacker/openime/CandidateSnapshot.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateSnapshot.kt
@@ -1,0 +1,72 @@
+package llc.slacker.openime
+
+/** One candidate exactly as it was rendered, optionally carrying its Rime identity. */
+internal data class CandidateSnapshotEntry(
+    val text: String,
+    val nativeReference: NativeCandidateReference? = null,
+)
+
+/**
+ * Immutable identity for one rendered candidate generation.
+ *
+ * Commit paths must consume this snapshot instead of re-querying Rime. That
+ * guarantees the text the user sees is the text that is committed, while a
+ * stale UI event cannot target a newer composition generation.
+ */
+internal data class CandidateSnapshot(
+    val generation: Long,
+    val composition: String,
+    val mode: KeyboardMode,
+    val entries: List<CandidateSnapshotEntry>,
+) {
+    val visibleCandidates: List<String>
+        get() = entries.map { it.text }
+
+    fun firstForCommit(
+        currentGeneration: Long,
+        currentComposition: String,
+        currentMode: KeyboardMode,
+    ): CandidateSnapshotEntry? =
+        if (matches(currentGeneration, currentComposition, currentMode)) entries.firstOrNull() else null
+
+    fun candidateForCommit(
+        candidate: String,
+        currentGeneration: Long,
+        currentComposition: String,
+        currentMode: KeyboardMode,
+    ): CandidateSnapshotEntry? =
+        if (matches(currentGeneration, currentComposition, currentMode)) {
+            entries.firstOrNull { it.text == candidate }
+        } else {
+            null
+        }
+
+    fun matches(
+        currentGeneration: Long,
+        currentComposition: String,
+        currentMode: KeyboardMode,
+    ): Boolean =
+        generation == currentGeneration &&
+            composition == currentComposition &&
+            mode == currentMode
+
+    companion object {
+        fun rendered(
+            generation: Long,
+            composition: String,
+            mode: KeyboardMode,
+            candidates: List<String>,
+            nativeReferences: Map<String, NativeCandidateReference> = emptyMap(),
+        ): CandidateSnapshot = CandidateSnapshot(
+            generation = generation,
+            composition = composition,
+            mode = mode,
+            entries = candidates.map { text ->
+                CandidateSnapshotEntry(
+                    text = text,
+                    nativeReference = nativeReferences[text],
+                )
+            },
+        )
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -66,7 +66,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         Thread(runnable, "ime-candidates").apply { isDaemon = true }
     }
     private val candidateGeneration = AtomicLong(0L)
-    private var nativeCandidateReferences: Map<String, NativeCandidateReference> = emptyMap()
+    private var renderedCandidateSnapshot: CandidateSnapshot? = null
     private var activeRimeInputs: List<String> = emptyList()
     @Volatile
     private var candidateDiagnostics = CandidateDiagnostics()
@@ -417,10 +417,17 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         keyboardView?.clearAssociationCandidates()
         if (lastComposition.isNotEmpty()) {
             val next = dropLastCodePoint(lastComposition)
-            val fallback = fallbackCandidatesFor(next, state.keyboardMode)
+            val mode = state.keyboardMode
+            val fallback = fallbackCandidatesFor(next, mode)
             val immediate = immediateCandidates(next, fallback)
             updateComposition(next, immediate)
-            requestNativeCandidates(next, state.keyboardMode, fallback)
+            val generation = requestNativeCandidates(next, mode, fallback)
+            renderedCandidateSnapshot = CandidateSnapshot.rendered(
+                generation = generation,
+                composition = next,
+                mode = mode,
+                candidates = immediate,
+            )
             // The view normally updates itself before this callback. If the
             // visible pre-edit field lost focus, however, the service owns the
             // deletion and must also remove stale candidate chips.
@@ -641,6 +648,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             gateway.commitText(ch.toString())
             lastComposition = ""
             state = state.copy(composition = "", candidates = emptyList())
+            renderedCandidateSnapshot = null
             keyboardView?.renderState(state)
             return
         }
@@ -656,10 +664,16 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             composition,
             immediate,
         )
-        // The view renders a fast local result first, then receives the
-        // authoritative librime ordering in the same callback.
+        val generation = requestNativeCandidates(composition, modeAtRequest, fallback, rimeInputs)
+        renderedCandidateSnapshot = CandidateSnapshot.rendered(
+            generation = generation,
+            composition = composition,
+            mode = modeAtRequest,
+            candidates = immediate,
+        )
+        // The view renders this exact snapshot first. A later native callback
+        // replaces both the rendered list and its immutable commit identity.
         keyboardView?.renderState(state)
-        requestNativeCandidates(composition, modeAtRequest, fallback, rimeInputs)
     }
 
     override fun onCandidateSelected(candidate: String) {
@@ -835,9 +849,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         mode: KeyboardMode,
         fallback: List<String>,
         rimeInputs: List<String> = listOf(composition),
-    ) {
+    ): Long {
         val request = candidateGeneration.incrementAndGet()
-        nativeCandidateReferences = emptyMap()
         val queryInputs = rimeInputs
             .asSequence()
             .map { it.trim() }
@@ -856,7 +869,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 fallbackCount = fallback.distinct().size,
                 finalCandidateSource = if (fallback.isEmpty()) "none" else "fallback",
             )
-            return
+            return request
         }
         candidateExecutor.execute {
             // Coalesce a burst of key events before entering librime. Older
@@ -886,7 +899,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 } else {
                     (learned + fallback).distinct().take(MAX_CANDIDATES)
                 }
-                nativeCandidateReferences = if (native.isNotEmpty()) {
+                val nativeReferences = if (native.isNotEmpty()) {
                     native.associate { it.text to it.reference }
                 } else {
                     emptyMap()
@@ -906,9 +919,17 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
                 )
                 Log.d(TAG, "candidate-stats ${candidateDiagnostics.asLogFields()}")
                 state = state.copy(candidates = finalCandidates)
+                renderedCandidateSnapshot = CandidateSnapshot.rendered(
+                    generation = request,
+                    composition = composition,
+                    mode = mode,
+                    candidates = finalCandidates,
+                    nativeReferences = nativeReferences,
+                )
                 keyboardView?.renderState(state)
             }
         }
+        return request
     }
 
     private fun queryNativeChoices(
@@ -928,73 +949,52 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         )
     }
 
-    /** Commit the authoritative first choice, even if the UI still shows the fast fallback. */
+    /** Commit only the first candidate that belongs to the currently rendered snapshot. */
     private fun commitFirstCandidate() {
         val composition = lastComposition
         if (composition.isEmpty()) return
         val mode = state.keyboardMode
-        val inputs = activeRimeInputs.ifEmpty { listOf(composition) }
-        val firstReference = state.candidates.firstOrNull()?.let(nativeCandidateReferences::get)
+        val entry = renderedCandidateSnapshot?.firstForCommit(
+            currentGeneration = candidateGeneration.get(),
+            currentComposition = composition,
+            currentMode = mode,
+        ) ?: return
         invalidateCandidateQueries()
+        val reference = entry.nativeReference
         val nativeCommit = if (
-            composition.length <= MAX_RIME_INPUT_LENGTH &&
+            reference != null &&
             rime.isReady &&
             (mode == KeyboardMode.PINYIN_26 || mode == KeyboardMode.PINYIN_9)
         ) {
-            when {
-                firstReference != null -> rime.selectCandidate(
-                    firstReference.input,
-                    firstReference.nativeIndex,
-                )
-                mode == KeyboardMode.PINYIN_9 -> {
-                    val reference = queryNativeChoices(inputs)?.choices?.firstOrNull()?.reference
-                    if (reference == null) "" else {
-                        rime.selectCandidate(reference.input, reference.nativeIndex)
-                    }
-                }
-                else -> rime.commitFirst(composition)
-            }
+            rime.selectCandidate(reference.input, reference.nativeIndex)
         } else {
             ""
         }
-        val committed = nativeCommit.ifBlank {
-            state.candidates.firstOrNull() ?: composition
-        }
-        finishCandidateCommit(composition, committed)
+        finishCandidateCommit(composition, nativeCommit.ifBlank { entry.text })
     }
 
     private fun selectCandidate(candidate: String) {
         val composition = lastComposition
+        if (composition.isEmpty()) return
         val mode = state.keyboardMode
-        val inputs = activeRimeInputs.ifEmpty { listOf(composition) }
-        val reference = nativeCandidateReferences[candidate]
+        val entry = renderedCandidateSnapshot?.candidateForCommit(
+            candidate = candidate,
+            currentGeneration = candidateGeneration.get(),
+            currentComposition = composition,
+            currentMode = mode,
+        ) ?: return
         invalidateCandidateQueries()
+        val reference = entry.nativeReference
         val nativeCommit = if (
-            composition.length <= MAX_RIME_INPUT_LENGTH &&
+            reference != null &&
             rime.isReady &&
-            (
-                mode == KeyboardMode.PINYIN_26 ||
-                    mode == KeyboardMode.PINYIN_9
-                )
+            (mode == KeyboardMode.PINYIN_26 || mode == KeyboardMode.PINYIN_9)
         ) {
-            if (reference != null) {
-                rime.selectCandidate(reference.input, reference.nativeIndex)
-            } else {
-                selectNativeCandidateByText(inputs, candidate)
-            }
+            rime.selectCandidate(reference.input, reference.nativeIndex)
         } else {
             ""
         }
-        val committed = nativeCommit.ifBlank { candidate }
-        finishCandidateCommit(composition, committed)
-    }
-
-    private fun selectNativeCandidateByText(inputs: List<String>, candidate: String): String {
-        inputs.take(MAX_RIME_NINE_KEY_PATHS).forEach { input ->
-            val committed = rime.selectCandidate(input, candidate)
-            if (committed.isNotEmpty()) return committed
-        }
-        return ""
+        finishCandidateCommit(composition, nativeCommit.ifBlank { entry.text })
     }
 
     private fun finishCandidateCommit(composition: String, committed: String) {
@@ -1155,7 +1155,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private fun invalidateCandidateQueries() {
         candidateGeneration.incrementAndGet()
-        nativeCandidateReferences = emptyMap()
+        renderedCandidateSnapshot = null
         activeRimeInputs = emptyList()
     }
 

--- a/app/src/test/java/llc/slacker/openime/CandidateSnapshotTest.kt
+++ b/app/src/test/java/llc/slacker/openime/CandidateSnapshotTest.kt
@@ -22,17 +22,32 @@ class CandidateSnapshotTest {
     }
 
     @Test
+    fun noCandidateChipCommitsVisibleRawComposition() {
+        val snapshot = CandidateSnapshot.rendered(
+            generation = 8,
+            composition = "vve",
+            mode = KeyboardMode.PINYIN_26,
+            candidates = emptyList(),
+        )
+
+        val entry = snapshot.firstForCommit(8, "vve", KeyboardMode.PINYIN_26)
+
+        assertEquals("vve", entry?.text)
+        assertNull(entry?.nativeReference)
+    }
+
+    @Test
     fun nativeEntryCarriesRenderedReference() {
         val reference = NativeCandidateReference(input = "ni", nativeIndex = 3)
         val snapshot = CandidateSnapshot.rendered(
-            generation = 8,
+            generation = 9,
             composition = "ni",
             mode = KeyboardMode.PINYIN_26,
             candidates = listOf("拟", "你"),
             nativeReferences = mapOf("拟" to reference),
         )
 
-        val entry = snapshot.firstForCommit(8, "ni", KeyboardMode.PINYIN_26)
+        val entry = snapshot.firstForCommit(9, "ni", KeyboardMode.PINYIN_26)
 
         assertEquals("拟", entry?.text)
         assertEquals(reference, entry?.nativeReference)
@@ -41,32 +56,32 @@ class CandidateSnapshotTest {
     @Test
     fun staleGenerationCannotCommit() {
         val snapshot = CandidateSnapshot.rendered(
-            generation = 9,
+            generation = 10,
             composition = "ni",
             mode = KeyboardMode.PINYIN_26,
             candidates = listOf("你"),
         )
 
-        assertNull(snapshot.firstForCommit(10, "ni", KeyboardMode.PINYIN_26))
-        assertNull(snapshot.candidateForCommit("你", 10, "ni", KeyboardMode.PINYIN_26))
+        assertNull(snapshot.firstForCommit(11, "ni", KeyboardMode.PINYIN_26))
+        assertNull(snapshot.candidateForCommit("你", 11, "ni", KeyboardMode.PINYIN_26))
     }
 
     @Test
     fun staleCompositionCannotCommitSameCandidateLabel() {
         val snapshot = CandidateSnapshot.rendered(
-            generation = 11,
+            generation = 12,
             composition = "ni",
             mode = KeyboardMode.PINYIN_26,
             candidates = listOf("你"),
         )
 
-        assertNull(snapshot.candidateForCommit("你", 11, "nimen", KeyboardMode.PINYIN_26))
+        assertNull(snapshot.candidateForCommit("你", 12, "nimen", KeyboardMode.PINYIN_26))
     }
 
     @Test
-    fun candidateClickMustExistInRenderedSnapshot() {
+    fun candidateClickMustExistInRenderedNineKeySnapshot() {
         val snapshot = CandidateSnapshot.rendered(
-            generation = 12,
+            generation = 13,
             composition = "7464",
             mode = KeyboardMode.PINYIN_9,
             candidates = listOf("是", "时"),
@@ -74,8 +89,8 @@ class CandidateSnapshotTest {
 
         assertEquals(
             "时",
-            snapshot.candidateForCommit("时", 12, "7464", KeyboardMode.PINYIN_9)?.text,
+            snapshot.candidateForCommit("时", 13, "7464", KeyboardMode.PINYIN_9)?.text,
         )
-        assertNull(snapshot.candidateForCommit("市", 12, "7464", KeyboardMode.PINYIN_9))
+        assertNull(snapshot.candidateForCommit("市", 13, "7464", KeyboardMode.PINYIN_9))
     }
 }

--- a/app/src/test/java/llc/slacker/openime/CandidateSnapshotTest.kt
+++ b/app/src/test/java/llc/slacker/openime/CandidateSnapshotTest.kt
@@ -1,0 +1,81 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CandidateSnapshotTest {
+
+    @Test
+    fun fallbackFirstCommitUsesExactlyRenderedText() {
+        val snapshot = CandidateSnapshot.rendered(
+            generation = 7,
+            composition = "ni",
+            mode = KeyboardMode.PINYIN_26,
+            candidates = listOf("你", "呢"),
+        )
+
+        val entry = snapshot.firstForCommit(7, "ni", KeyboardMode.PINYIN_26)
+
+        assertEquals("你", entry?.text)
+        assertNull(entry?.nativeReference)
+    }
+
+    @Test
+    fun nativeEntryCarriesRenderedReference() {
+        val reference = NativeCandidateReference(input = "ni", nativeIndex = 3)
+        val snapshot = CandidateSnapshot.rendered(
+            generation = 8,
+            composition = "ni",
+            mode = KeyboardMode.PINYIN_26,
+            candidates = listOf("拟", "你"),
+            nativeReferences = mapOf("拟" to reference),
+        )
+
+        val entry = snapshot.firstForCommit(8, "ni", KeyboardMode.PINYIN_26)
+
+        assertEquals("拟", entry?.text)
+        assertEquals(reference, entry?.nativeReference)
+    }
+
+    @Test
+    fun staleGenerationCannotCommit() {
+        val snapshot = CandidateSnapshot.rendered(
+            generation = 9,
+            composition = "ni",
+            mode = KeyboardMode.PINYIN_26,
+            candidates = listOf("你"),
+        )
+
+        assertNull(snapshot.firstForCommit(10, "ni", KeyboardMode.PINYIN_26))
+        assertNull(snapshot.candidateForCommit("你", 10, "ni", KeyboardMode.PINYIN_26))
+    }
+
+    @Test
+    fun staleCompositionCannotCommitSameCandidateLabel() {
+        val snapshot = CandidateSnapshot.rendered(
+            generation = 11,
+            composition = "ni",
+            mode = KeyboardMode.PINYIN_26,
+            candidates = listOf("你"),
+        )
+
+        assertNull(snapshot.candidateForCommit("你", 11, "nimen", KeyboardMode.PINYIN_26))
+    }
+
+    @Test
+    fun candidateClickMustExistInRenderedSnapshot() {
+        val snapshot = CandidateSnapshot.rendered(
+            generation = 12,
+            composition = "7464",
+            mode = KeyboardMode.PINYIN_9,
+            candidates = listOf("是", "时"),
+        )
+
+        assertEquals(
+            "时",
+            snapshot.candidateForCommit("时", 12, "7464", KeyboardMode.PINYIN_9)?.text,
+        )
+        assertNull(snapshot.candidateForCommit("市", 12, "7464", KeyboardMode.PINYIN_9))
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an immutable `CandidateSnapshot` for each rendered candidate generation
- make space/enter commit the exact first candidate currently visible instead of re-querying Rime during commit
- make candidate taps valid only when the label belongs to the current generation/composition/mode snapshot
- carry native Rime input/index references only when those native candidates have actually been rendered
- preserve raw pre-edit commit when no candidate chip is visible
- add JVM regression coverage for fallback/native/raw/stale-generation and nine-key snapshot behavior

This intentionally does not address the remaining Rime lock/main-thread latency issue in #12; native selections can still contend on the Rime lock. It only fixes display/commit identity.

Closes #6