### PR TITLE
Keep Rime mutations off the IME commit thread

### DIFF
--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -17,6 +17,37 @@ internal fun rimeProbeHasCandidate(snapshot: Array<String>): Boolean =
 internal fun rimeDataRevision(versionCode: Long): String = "apk-$versionCode"
 
 /**
+ * One serial lane for native mutations that must never stall the IME thread.
+ * Candidate discovery stays synchronous for the existing background candidate
+ * worker; selection learning and clear operations are queued here instead.
+ */
+internal class RimeMutationQueue(
+    threadName: String = "local-rime-mutations",
+) : AutoCloseable {
+    private val executor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, threadName).apply { isDaemon = true }
+    }
+
+    @Volatile
+    private var closed = false
+
+    fun submit(operation: () -> Unit): Boolean {
+        if (closed) return false
+        return runCatching {
+            executor.execute {
+                if (!closed) operation()
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    override fun close() {
+        closed = true
+        executor.shutdownNow()
+    }
+}
+
+/**
  * Tracks ownership of one asynchronous startup attempt. Destroy invalidates the
  * current generation immediately; a stale worker may clean native state, but it
  * can never publish READY after its owner has gone away.
@@ -71,6 +102,7 @@ internal class RimeStartupGate {
 class RimeEngine(private val context: Context) {
     private val lock = Any()
     private val startupGate = RimeStartupGate()
+    private val mutationQueue = RimeMutationQueue()
     private val startupExecutor = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "local-rime-startup").apply { isDaemon = true }
     }
@@ -167,16 +199,27 @@ class RimeEngine(private val context: Context) {
         }
     }
 
-    /** Select an entry previously returned by [candidateEntries]. */
+    /**
+     * Queue learning for an already-rendered native entry and return
+     * immediately. The editor commit is owned by CandidateSnapshot, so the IME
+     * thread never needs native committed text here.
+     */
     fun selectCandidate(input: String, nativeIndex: Int): String {
         val normalized = RimeInputNormalizer.normalize(input)
         if (!isReady || normalized.isBlank() || nativeIndex < 0) return ""
-        return synchronized(lock) {
-            runCatching {
-                RimeNative.nativeSetInput(normalized)
-                RimeNative.nativeSelectCandidate(nativeIndex)
-            }.getOrDefault("")
+        mutationQueue.submit {
+            if (isReady) {
+                synchronized(lock) {
+                    if (isReady) {
+                        runCatching {
+                            RimeNative.nativeSetInput(normalized)
+                            RimeNative.nativeSelectCandidate(nativeIndex)
+                        }
+                    }
+                }
+            }
         }
+        return ""
     }
 
     fun commitFirst(input: String): String {
@@ -190,16 +233,22 @@ class RimeEngine(private val context: Context) {
         }
     }
 
+    /** Queue session cleanup instead of waiting for an in-flight native query. */
     fun clear() {
         if (!isReady) return
-        synchronized(lock) {
-            runCatching { RimeNative.nativeClear() }
+        mutationQueue.submit {
+            if (isReady) {
+                synchronized(lock) {
+                    if (isReady) runCatching { RimeNative.nativeClear() }
+                }
+            }
         }
     }
 
     fun shutdown() {
         startupGate.destroy()
         isReady = false
+        mutationQueue.close()
         cleanupNative()
         startupExecutor.shutdownNow()
     }

--- a/app/src/test/java/llc/slacker/openime/RimeMutationQueueTest.kt
+++ b/app/src/test/java/llc/slacker/openime/RimeMutationQueueTest.kt
@@ -1,0 +1,77 @@
+package llc.slacker.openime
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RimeMutationQueueTest {
+
+    @Test
+    fun submitReturnsWhileEarlierNativeWorkIsStillBlocked() {
+        val queue = RimeMutationQueue("rime-mutation-test")
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondDone = CountDownLatch(1)
+        try {
+            assertTrue(
+                queue.submit {
+                    firstStarted.countDown()
+                    releaseFirst.await()
+                },
+            )
+            assertTrue(firstStarted.await(1, TimeUnit.SECONDS))
+
+            // This models a space/candidate commit arriving while an earlier
+            // native candidate operation still owns the Rime lock. submit()
+            // itself must return instead of waiting for that operation.
+            assertTrue(queue.submit { secondDone.countDown() })
+            assertEquals(1L, secondDone.count)
+
+            releaseFirst.countDown()
+            assertTrue(secondDone.await(1, TimeUnit.SECONDS))
+        } finally {
+            releaseFirst.countDown()
+            queue.close()
+        }
+    }
+
+    @Test
+    fun mutationsStaySerial() {
+        val queue = RimeMutationQueue("rime-serial-test")
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondDone = CountDownLatch(1)
+        val order = mutableListOf<Int>()
+        try {
+            queue.submit {
+                synchronized(order) { order += 1 }
+                firstStarted.countDown()
+                releaseFirst.await()
+                synchronized(order) { order += 2 }
+            }
+            assertTrue(firstStarted.await(1, TimeUnit.SECONDS))
+            queue.submit {
+                synchronized(order) { order += 3 }
+                secondDone.countDown()
+            }
+
+            releaseFirst.countDown()
+            assertTrue(secondDone.await(1, TimeUnit.SECONDS))
+            assertEquals(listOf(1, 2, 3), synchronized(order) { order.toList() })
+        } finally {
+            releaseFirst.countDown()
+            queue.close()
+        }
+    }
+
+    @Test
+    fun closedQueueRejectsNewMutation() {
+        val queue = RimeMutationQueue("rime-closed-test")
+        queue.close()
+
+        assertFalse(queue.submit { error("must not run") })
+    }
+}


### PR DESCRIPTION
## Summary
- add one serial `RimeMutationQueue` for native mutations that do not need to block editor commits
- make indexed candidate selection (the path used by rendered CandidateSnapshot references) enqueue Rime learning and return immediately
- make `clear()` enqueue behind learning instead of waiting for an in-flight candidate query on the caller thread
- keep candidate discovery synchronous only for the existing background candidate worker
- re-check `isReady` inside queued mutations so shutdown cannot run stale native work
- add deterministic concurrency tests proving submit is non-blocking while earlier native work is blocked, mutation order remains serial, and closed queues reject work

#6 is the prerequisite: editor text now comes from the rendered CandidateSnapshot, so native selection is needed only for Rime learning and no longer for deciding what text to commit.

Closes #12