### PR TITLE
Track voice corrections with absolute editor coordinates

### DIFF
--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -49,6 +49,20 @@ class InputConnectionGateway(
         val cursor: Int,
     )
 
+    data class AbsoluteCursorSnapshot(
+        val text: String,
+        val windowStart: Int,
+        val cursorAbsolute: Int,
+    ) {
+        fun textInAbsoluteRange(startAbsolute: Int, endAbsolute: Int): String? {
+            if (endAbsolute < startAbsolute) return null
+            val localStart = startAbsolute - windowStart
+            val localEnd = endAbsolute - windowStart
+            if (localStart < 0 || localEnd < localStart || localEnd > text.length) return null
+            return text.substring(localStart, localEnd)
+        }
+    }
+
     fun commitText(text: String) {
         if (text.isEmpty()) return
         connection()?.commitText(text, 1)
@@ -234,6 +248,24 @@ class InputConnectionGateway(
         val after = runCatching { ic.getTextAfterCursor(bounded, 0)?.toString().orEmpty() }
             .getOrDefault("")
         return CursorSnapshot(before + after, before.length)
+    }
+
+    /**
+     * Snapshot a collapsed cursor using ExtractedText.startOffset so every
+     * coordinate is tied to the document rather than to a sliding local window.
+     */
+    fun absoluteCursorSnapshot(): AbsoluteCursorSnapshot? {
+        if (isPassword()) return null
+        val ic = connection() ?: return null
+        val window = extractedWindow(ic) ?: return null
+        if (window.selectionStartAbsolute != window.selectionEndAbsolute) return null
+        val localCursor = window.selectionEndAbsolute - window.windowStart
+        if (localCursor !in 0..window.text.length) return null
+        return AbsoluteCursorSnapshot(
+            text = window.text,
+            windowStart = window.windowStart,
+            cursorAbsolute = window.selectionEndAbsolute,
+        )
     }
 
     fun copySelection(): String {

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -1032,7 +1032,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             pendingVoiceCorrection = null
             return
         }
-        if (cursorAbsolute in pending.range.startAbsolute until pending.range.endAbsolute) {
+        if (cursorAbsolute in (pending.range.startAbsolute + 1)..pending.range.endAbsolute) {
             pending.edited = true
         } else if (!pending.edited) {
             pendingVoiceCorrection = null

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -39,9 +39,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     )
 
     private data class PendingVoiceCorrection(
-        val original: String,
-        val start: Int,
-        val end: Int,
+        val range: VoiceCorrectionRange,
         var edited: Boolean = false,
     )
 
@@ -1020,28 +1018,21 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             pendingVoiceCorrection = null
             return
         }
-        val snapshot = gateway.cursorSnapshot() ?: run {
+        val snapshot = gateway.absoluteCursorSnapshot() ?: run {
             pendingVoiceCorrection = null
             return
         }
-        val start = snapshot.cursor - original.length
-        pendingVoiceCorrection = if (
-            start >= 0 && snapshot.cursor <= snapshot.text.length &&
-            snapshot.text.substring(start, snapshot.cursor) == original
-        ) {
-            PendingVoiceCorrection(original = original, start = start, end = snapshot.cursor)
-        } else {
-            null
-        }
+        val range = voiceCorrectionRange(original, snapshot)
+        pendingVoiceCorrection = range?.let(::PendingVoiceCorrection)
     }
 
     private fun noteVoiceBackspace() {
         val pending = pendingVoiceCorrection ?: return
-        val cursor = gateway.cursorSnapshot()?.cursor ?: run {
+        val cursorAbsolute = gateway.absoluteCursorSnapshot()?.cursorAbsolute ?: run {
             pendingVoiceCorrection = null
             return
         }
-        if (cursor in (pending.start + 1)..pending.end) {
+        if (cursorAbsolute in pending.range.startAbsolute until pending.range.endAbsolute) {
             pending.edited = true
         } else if (!pending.edited) {
             pendingVoiceCorrection = null
@@ -1059,12 +1050,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         val pending = pendingVoiceCorrection ?: return
         pendingVoiceCorrection = null
         if (!pending.edited || state.passwordField) return
-        val snapshot = gateway.cursorSnapshot() ?: return
-        val end = snapshot.cursor
-        if (pending.start !in 0..snapshot.text.length || end < pending.start) return
-        if (end - pending.start > 128 || end > snapshot.text.length) return
-        val corrected = snapshot.text.substring(pending.start, end)
-        VoiceCorrectionRepository.record(pending.original, corrected)
+        val snapshot = gateway.absoluteCursorSnapshot() ?: return
+        val corrected = correctedVoiceText(pending.range, snapshot) ?: return
+        VoiceCorrectionRepository.record(pending.range.original, corrected)
     }
 
     private fun dropLastCodePoint(text: String): String = dropLastCodePointSafe(text)

--- a/app/src/main/java/llc/slacker/openime/VoiceCorrectionRange.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceCorrectionRange.kt
@@ -1,0 +1,35 @@
+package llc.slacker.openime
+
+/** Absolute editor range used to track one committed ASR result across window shifts. */
+internal data class VoiceCorrectionRange(
+    val original: String,
+    val startAbsolute: Int,
+    val endAbsolute: Int,
+)
+
+internal fun voiceCorrectionRange(
+    original: String,
+    snapshot: InputConnectionGateway.AbsoluteCursorSnapshot,
+): VoiceCorrectionRange? {
+    if (original.isBlank()) return null
+    val end = snapshot.cursorAbsolute
+    val start = end - original.length
+    if (start < 0) return null
+    if (snapshot.textInAbsoluteRange(start, end) != original) return null
+    return VoiceCorrectionRange(
+        original = original,
+        startAbsolute = start,
+        endAbsolute = end,
+    )
+}
+
+internal fun correctedVoiceText(
+    range: VoiceCorrectionRange,
+    snapshot: InputConnectionGateway.AbsoluteCursorSnapshot,
+    maxLength: Int = 128,
+): String? {
+    val end = snapshot.cursorAbsolute
+    if (end < range.startAbsolute) return null
+    if (end - range.startAbsolute > maxLength) return null
+    return snapshot.textInAbsoluteRange(range.startAbsolute, end)
+}

--- a/app/src/test/java/llc/slacker/openime/VoiceCorrectionRangeTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoiceCorrectionRangeTest.kt
@@ -1,0 +1,69 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class VoiceCorrectionRangeTest {
+
+    @Test
+    fun longDocumentAnchorUsesAbsoluteEditorCoordinates() {
+        val original = "开放爱慕"
+        val localPrefix = "x".repeat(8_190)
+        val windowStart = 25_000
+        val text = localPrefix + original
+        val snapshot = InputConnectionGateway.AbsoluteCursorSnapshot(
+            text = text,
+            windowStart = windowStart,
+            cursorAbsolute = windowStart + text.length,
+        )
+
+        val range = assertNotNull(voiceCorrectionRange(original, snapshot)) as VoiceCorrectionRange
+
+        assertEquals(33_190, range.startAbsolute)
+        assertEquals(33_194, range.endAbsolute)
+    }
+
+    @Test
+    fun shiftedSurroundingWindowExtractsOnlyTheActualReplacement() {
+        val original = "彭拜系统"
+        val originalWindowStart = 24_000
+        val originalLocalStart = 8_100
+        val originalText = "a".repeat(originalLocalStart) + original
+        val initial = InputConnectionGateway.AbsoluteCursorSnapshot(
+            text = originalText,
+            windowStart = originalWindowStart,
+            cursorAbsolute = originalWindowStart + originalText.length,
+        )
+        val range = assertNotNull(voiceCorrectionRange(original, initial)) as VoiceCorrectionRange
+
+        val corrected = "澎湃系统"
+        val shiftedWindowStart = originalWindowStart + 37
+        val shiftedLocalStart = range.startAbsolute - shiftedWindowStart
+        val shiftedText = "b".repeat(shiftedLocalStart) + corrected + "tail"
+        val shifted = InputConnectionGateway.AbsoluteCursorSnapshot(
+            text = shiftedText,
+            windowStart = shiftedWindowStart,
+            cursorAbsolute = range.startAbsolute + corrected.length,
+        )
+
+        assertEquals(corrected, correctedVoiceText(range, shifted))
+    }
+
+    @Test
+    fun learningIsSkippedWhenShiftedWindowNoLongerContainsAnchor() {
+        val range = VoiceCorrectionRange(
+            original = "语音原文",
+            startAbsolute = 31_000,
+            endAbsolute = 31_004,
+        )
+        val shifted = InputConnectionGateway.AbsoluteCursorSnapshot(
+            text = "修正文本",
+            windowStart = 31_001,
+            cursorAbsolute = 31_004,
+        )
+
+        assertNull(correctedVoiceText(range, shifted))
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/VoiceCorrectionRangeTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoiceCorrectionRangeTest.kt
@@ -2,7 +2,6 @@ package llc.slacker.openime
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class VoiceCorrectionRangeTest {
@@ -19,7 +18,7 @@ class VoiceCorrectionRangeTest {
             cursorAbsolute = windowStart + text.length,
         )
 
-        val range = assertNotNull(voiceCorrectionRange(original, snapshot)) as VoiceCorrectionRange
+        val range = requireNotNull(voiceCorrectionRange(original, snapshot))
 
         assertEquals(33_190, range.startAbsolute)
         assertEquals(33_194, range.endAbsolute)
@@ -36,7 +35,7 @@ class VoiceCorrectionRangeTest {
             windowStart = originalWindowStart,
             cursorAbsolute = originalWindowStart + originalText.length,
         )
-        val range = assertNotNull(voiceCorrectionRange(original, initial)) as VoiceCorrectionRange
+        val range = requireNotNull(voiceCorrectionRange(original, initial))
 
         val corrected = "澎湃系统"
         val shiftedWindowStart = originalWindowStart + 37


### PR DESCRIPTION
## Summary
- add an absolute cursor snapshot backed by `ExtractedText.startOffset` for voice-correction learning
- persist ASR replacement anchors in document coordinates instead of bounded local-window offsets
- extract corrected text only when the current editor window still contains the original absolute anchor; otherwise skip learning rather than ingest adjacent document text
- cover 30k+ document offsets, shifted surrounding windows, and anchor-loss fallback with JVM tests

Closes #10