### PR TITLE
Make fuzzy Pinyin affect native Rime candidates

### DIFF
--- a/app/src/main/assets/rime-data/default.yaml
+++ b/app/src/main/assets/rime-data/default.yaml
@@ -6,6 +6,7 @@ config_version: '0.40'
 schema_list:
   - schema: luna_pinyin
   - schema: luna_pinyin_simp
+  - schema: luna_pinyin_simp_fuzzy
   - schema: luna_pinyin_fluency
   - schema: bopomofo
   - schema: bopomofo_tw

--- a/app/src/main/assets/rime-data/luna_pinyin_simp_fuzzy.schema.yaml
+++ b/app/src/main/assets/rime-data/luna_pinyin_simp_fuzzy.schema.yaml
@@ -1,0 +1,28 @@
+# Rime schema
+# encoding: utf-8
+
+__include: luna_pinyin_simp.schema:/
+
+schema:
+  schema_id: luna_pinyin_simp_fuzzy
+  name: 朙月拼音·简化字·模糊音
+  version: "0.22"
+  author:
+    - 佛振 <chen.sst@gmail.com>
+  description: |
+    朙月拼音简化字方案，额外启用 openIME 模糊音规则。
+
+speller:
+  algebra:
+    __patch:
+      - pinyin:/zh_z_bufen
+      - pinyin:/n_l_bufen
+      - pinyin:/en_eng_bufen
+      - pinyin:/abbreviation
+      - pinyin:/spelling_correction
+      - pinyin:/key_correction
+
+translator:
+  # Fuzzy algebra must use its own prism; reusing luna_pinyin_simp would keep
+  # the non-fuzzy compiled spelling graph even after selecting this schema.
+  prism: luna_pinyin_simp_fuzzy

--- a/app/src/main/cpp/local_rime_jni.cc
+++ b/app/src/main/cpp/local_rime_jni.cc
@@ -228,6 +228,11 @@ std::vector<std::string> snapshot_locked() {
   return values;
 }
 
+bool select_schema_locked(const std::string& schema_id) {
+  return g_api && g_session && g_api->select_schema && !schema_id.empty() &&
+         g_api->select_schema(g_session, schema_id.c_str());
+}
+
 void shutdown_locked() {
   if (g_api && g_session) g_api->destroy_session(g_session);
   g_session = 0;
@@ -284,13 +289,20 @@ Java_llc_slacker_openime_RimeNative_nativeStartup(
   // A live session is not sufficient: without a selected schema every later
   // candidate query is empty. Require one of the bundled Pinyin schemas.
   const bool schema_selected =
-      g_api->select_schema &&
-      (g_api->select_schema(g_session, "luna_pinyin_simp") ||
-       g_api->select_schema(g_session, "luna_pinyin"));
+      select_schema_locked("luna_pinyin_simp") ||
+      select_schema_locked("luna_pinyin");
   if (!schema_selected) {
     g_api->destroy_session(g_session);
     g_session = 0;
   }
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_llc_slacker_openime_RimeNative_nativeSelectSchema(
+    JNIEnv* env, jclass, jstring schema_id) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  const std::string schema = jstring_to_utf8(env, schema_id);
+  return select_schema_locked(schema) ? JNI_TRUE : JNI_FALSE;
 }
 
 extern "C" JNIEXPORT jobjectArray JNICALL

--- a/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
@@ -326,23 +326,7 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         return best[py.length]?.takeIf { it.parts >= 2 }?.text
     }
 
-    private fun fuzzyVariants(py: String): List<String> {
-        val out = mutableSetOf<String>()
-        val pairs = listOf(
-            "z" to "zh",
-            "c" to "ch",
-            "s" to "sh",
-        )
-        for ((short, long) in pairs) {
-            if (py.startsWith(short) && !py.startsWith(long)) {
-                out.add(long + py.substring(short.length))
-            }
-            if (py.startsWith(long)) {
-                out.add(short + py.substring(long.length))
-            }
-        }
-        return out.toList()
-    }
+    private fun fuzzyVariants(py: String): List<String> = pinyinFuzzyVariants(py)
 
     fun get9KeyCandidates(numberStr: String): NineKeyResult {
         val digits = numberStr

--- a/app/src/main/java/llc/slacker/openime/PinyinFuzzyRules.kt
+++ b/app/src/main/java/llc/slacker/openime/PinyinFuzzyRules.kt
@@ -1,0 +1,48 @@
+package llc.slacker.openime
+
+/**
+ * Kotlin fallback counterpart of the fuzzy algebra enabled by
+ * luna_pinyin_simp_fuzzy.schema.yaml. Keep this limited to the product's three
+ * supported fuzzy groups so fallback and librime expose the same semantics.
+ */
+internal fun pinyinFuzzyVariants(rawPinyin: String): List<String> {
+    val pinyin = rawPinyin.lowercase()
+    if (pinyin.isEmpty()) return emptyList()
+
+    val variants = linkedSetOf<String>()
+    val pending = mutableListOf(pinyin)
+    var cursor = 0
+
+    fun enqueue(candidate: String) {
+        if (candidate != pinyin && variants.size < MAX_FUZZY_VARIANTS && variants.add(candidate)) {
+            pending.add(candidate)
+        }
+    }
+
+    while (cursor < pending.size && variants.size < MAX_FUZZY_VARIANTS) {
+        val value = pending[cursor++]
+
+        listOf("zh" to "z", "ch" to "c", "sh" to "s").forEach { (long, short) ->
+            when {
+                value.startsWith(long) -> enqueue(short + value.substring(long.length))
+                value.startsWith(short) -> enqueue(long + value.substring(short.length))
+            }
+        }
+
+        when {
+            value.startsWith('n') -> enqueue("l" + value.substring(1))
+            value.startsWith('l') -> enqueue("n" + value.substring(1))
+        }
+
+        when {
+            value.endsWith("eng") -> enqueue(value.dropLast(3) + "en")
+            value.endsWith("en") -> enqueue(value.dropLast(2) + "eng")
+            value.endsWith("ing") -> enqueue(value.dropLast(3) + "in")
+            value.endsWith("in") -> enqueue(value.dropLast(2) + "ing")
+        }
+    }
+
+    return variants.toList()
+}
+
+private const val MAX_FUZZY_VARIANTS = 16

--- a/app/src/main/java/llc/slacker/openime/PinyinFuzzyRules.kt
+++ b/app/src/main/java/llc/slacker/openime/PinyinFuzzyRules.kt
@@ -30,8 +30,8 @@ internal fun pinyinFuzzyVariants(rawPinyin: String): List<String> {
         }
 
         when {
-            value.startsWith('n') -> enqueue("l" + value.substring(1))
-            value.startsWith('l') -> enqueue("n" + value.substring(1))
+            value.startsWith("n") -> enqueue("l" + value.substring(1))
+            value.startsWith("l") -> enqueue("n" + value.substring(1))
         }
 
         when {

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -227,7 +227,10 @@ class RimeEngine(private val context: Context) {
                 synchronized(lock) {
                     if (isReady) {
                         runCatching {
-                            if (!syncSchemaFromSettingsLocked()) return@runCatching
+                            // nativeIndex belongs to the schema that produced the
+                            // rendered snapshot. Do not switch schemas between
+                            // rendering and consuming that index; the next native
+                            // candidate query will synchronize a changed setting.
                             RimeNative.nativeSetInput(normalized)
                             RimeNative.nativeSelectCandidate(nativeIndex)
                         }

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -16,6 +16,9 @@ internal fun rimeProbeHasCandidate(snapshot: Array<String>): Boolean =
 
 internal fun rimeDataRevision(versionCode: Long): String = "apk-$versionCode"
 
+internal fun rimeSchemaId(fuzzyEnabled: Boolean): String =
+    if (fuzzyEnabled) "luna_pinyin_simp_fuzzy" else "luna_pinyin_simp"
+
 /**
  * One serial lane for native mutations that must never stall the IME thread.
  * Candidate discovery stays synchronous for the existing background candidate
@@ -106,6 +109,7 @@ class RimeEngine(private val context: Context) {
     private val startupExecutor = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "local-rime-startup").apply { isDaemon = true }
     }
+    private var activeSchemaId: String? = null
     @Volatile
     var isReady: Boolean = false
         private set
@@ -136,6 +140,12 @@ class RimeEngine(private val context: Context) {
                 }
 
                 synchronized(lock) {
+                    // The persisted fuzzy setting is the source of truth for the
+                    // live native session. Select the matching schema before the
+                    // health probe so READY never publishes with stale semantics.
+                    check(syncSchemaFromSettingsLocked()) {
+                        "librime requested schema unavailable"
+                    }
                     // Prove that the selected schema and translator are actually
                     // usable. An empty-input snapshot can look non-empty even
                     // when no schema can produce candidates.
@@ -154,7 +164,7 @@ class RimeEngine(private val context: Context) {
                 }
                 errorMessage = ""
                 isReady = true
-                Log.i(TAG, "librime ready")
+                Log.i(TAG, "librime ready schema=$activeSchemaId")
             } catch (throwable: Throwable) {
                 if (nativeStartupReturned) cleanupNative()
                 if (startupGate.fail(generation)) {
@@ -181,7 +191,11 @@ class RimeEngine(private val context: Context) {
         if (!isReady || normalized.isBlank()) return emptyList()
         return synchronized(lock) {
             runCatching {
-                snapshotCandidateEntries(RimeNative.nativeSetInput(normalized))
+                if (!syncSchemaFromSettingsLocked()) {
+                    emptyList()
+                } else {
+                    snapshotCandidateEntries(RimeNative.nativeSetInput(normalized))
+                }
             }.getOrDefault(emptyList())
         }
     }
@@ -192,6 +206,7 @@ class RimeEngine(private val context: Context) {
         if (!isReady || normalized.isBlank()) return ""
         return synchronized(lock) {
             runCatching {
+                if (!syncSchemaFromSettingsLocked()) return@runCatching ""
                 val snapshot = RimeNative.nativeSetInput(normalized)
                 val entry = snapshotCandidateEntries(snapshot).firstOrNull { it.text == candidate }
                 if (entry != null) RimeNative.nativeSelectCandidate(entry.nativeIndex) else ""
@@ -212,6 +227,7 @@ class RimeEngine(private val context: Context) {
                 synchronized(lock) {
                     if (isReady) {
                         runCatching {
+                            if (!syncSchemaFromSettingsLocked()) return@runCatching
                             RimeNative.nativeSetInput(normalized)
                             RimeNative.nativeSelectCandidate(nativeIndex)
                         }
@@ -227,6 +243,7 @@ class RimeEngine(private val context: Context) {
         if (!isReady || normalized.isBlank()) return ""
         return synchronized(lock) {
             runCatching {
+                if (!syncSchemaFromSettingsLocked()) return@runCatching ""
                 RimeNative.nativeSetInput(normalized)
                 RimeNative.nativeCommitFirst()
             }.getOrDefault("")
@@ -253,8 +270,19 @@ class RimeEngine(private val context: Context) {
         startupExecutor.shutdownNow()
     }
 
+    private fun syncSchemaFromSettingsLocked(): Boolean {
+        val desiredSchemaId = rimeSchemaId(ImeSettingsRepository.loadFuzzy(context))
+        if (activeSchemaId == desiredSchemaId) return true
+        if (!RimeNative.nativeSelectSchema(desiredSchemaId)) return false
+        activeSchemaId = desiredSchemaId
+        RimeNative.nativeClear()
+        Log.i(TAG, "librime schema=$desiredSchemaId")
+        return true
+    }
+
     private fun cleanupNative() {
         synchronized(lock) {
+            activeSchemaId = null
             runCatching { RimeNative.nativeShutdown() }
         }
     }
@@ -274,7 +302,10 @@ class RimeEngine(private val context: Context) {
         // generation is disabled and automatically changes on every upgrade.
         val revision = rimeDataRevision(installedVersionCode())
         val marker = File(sharedDir, ".openime-rime-$revision")
-        if (marker.exists() && File(sharedDir, "luna_pinyin_simp.schema.yaml").exists()) return
+        val requiredSchemasPresent =
+            File(sharedDir, "luna_pinyin_simp.schema.yaml").exists() &&
+                File(sharedDir, "luna_pinyin_simp_fuzzy.schema.yaml").exists()
+        if (marker.exists() && requiredSchemasPresent) return
         deleteChildren(sharedDir)
         copyAssetTree("rime-data", sharedDir)
         marker.writeText("openIME Rime data revision $revision\n")

--- a/app/src/main/java/llc/slacker/openime/RimeNative.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeNative.kt
@@ -10,6 +10,9 @@ internal object RimeNative {
     external fun nativeStartup(sharedDir: String, userDir: String)
 
     @JvmStatic
+    external fun nativeSelectSchema(schemaId: String): Boolean
+
+    @JvmStatic
     external fun nativeSetInput(input: String): Array<String>
 
     @JvmStatic
@@ -28,4 +31,3 @@ internal object RimeNative {
     @JvmStatic
     external fun nativeUtf8RoundTripForTest(input: String): String
 }
-

--- a/app/src/test/java/llc/slacker/openime/PinyinFuzzyRulesTest.kt
+++ b/app/src/test/java/llc/slacker/openime/PinyinFuzzyRulesTest.kt
@@ -1,0 +1,39 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PinyinFuzzyRulesTest {
+
+    @Test
+    fun coversZhZInBothDirections() {
+        assertTrue("za" in pinyinFuzzyVariants("zha"))
+        assertTrue("zha" in pinyinFuzzyVariants("za"))
+    }
+
+    @Test
+    fun coversNLInBothDirections() {
+        assertTrue("lan" in pinyinFuzzyVariants("nan"))
+        assertTrue("nan" in pinyinFuzzyVariants("lan"))
+    }
+
+    @Test
+    fun coversEnEngAndInIngInBothDirections() {
+        assertTrue("ben" in pinyinFuzzyVariants("beng"))
+        assertTrue("beng" in pinyinFuzzyVariants("ben"))
+        assertTrue("pin" in pinyinFuzzyVariants("ping"))
+        assertTrue("ping" in pinyinFuzzyVariants("pin"))
+    }
+
+    @Test
+    fun combinesIndependentFuzzyGroupsWithoutReturningOriginal() {
+        val variants = pinyinFuzzyVariants("zheng")
+        assertTrue("zeng" in variants)
+        assertTrue("zhen" in variants)
+        assertTrue("zen" in variants)
+        assertFalse("zheng" in variants)
+        assertEquals(variants.distinct(), variants)
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/RimeFuzzySchemaTest.kt
+++ b/app/src/test/java/llc/slacker/openime/RimeFuzzySchemaTest.kt
@@ -1,0 +1,48 @@
+package llc.slacker.openime
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RimeFuzzySchemaTest {
+
+    private fun asset(relative: String): File = sequenceOf(
+        File("src/main/assets/$relative"),
+        File("app/src/main/assets/$relative"),
+    ).firstOrNull { it.isFile } ?: error("missing test asset: $relative")
+
+    @Test
+    fun fuzzySettingMapsToDistinctNativeSchemas() {
+        assertEquals("luna_pinyin_simp", rimeSchemaId(fuzzyEnabled = false))
+        assertEquals("luna_pinyin_simp_fuzzy", rimeSchemaId(fuzzyEnabled = true))
+    }
+
+    @Test
+    fun fuzzySchemaIsDeployedWithIndependentPrismAndRequiredRules() {
+        val defaults = asset("rime-data/default.yaml").readText()
+        val schema = asset("rime-data/luna_pinyin_simp_fuzzy.schema.yaml").readText()
+
+        assertTrue(defaults.contains("- schema: luna_pinyin_simp_fuzzy"))
+        assertTrue(schema.contains("schema_id: luna_pinyin_simp_fuzzy"))
+        assertTrue(schema.contains("prism: luna_pinyin_simp_fuzzy"))
+        listOf(
+            "pinyin:/zh_z_bufen",
+            "pinyin:/n_l_bufen",
+            "pinyin:/en_eng_bufen",
+            "pinyin:/abbreviation",
+            "pinyin:/spelling_correction",
+            "pinyin:/key_correction",
+        ).forEach { rule ->
+            assertTrue("missing fuzzy schema rule: $rule", schema.contains(rule))
+        }
+    }
+
+    @Test
+    fun normalSchemaDoesNotEnableFuzzyRules() {
+        val schema = asset("rime-data/luna_pinyin.schema.yaml").readText()
+        listOf("zh_z_bufen", "n_l_bufen", "en_eng_bufen").forEach { rule ->
+            assertTrue("normal schema unexpectedly enables $rule", !schema.contains("pinyin:/$rule"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated simplified fuzzy Rime schema with `zh/z`, `n/l`, and `en/eng` rules before the existing abbreviation/correction rules
- give the fuzzy schema its own prism and deploy it with the bundled schema list
- expose runtime schema selection through JNI and make `RimeEngine` synchronize the live session with the persisted fuzzy setting
- align the Kotlin fallback with the same three fuzzy groups so behavior is consistent before and after Rime becomes ready
- keep rendered native candidate indexes bound to the schema that produced them
- force existing installs to refresh bundled Rime data when the fuzzy schema is missing
- add regression coverage for schema separation and `zh/z`, `n/l`, `en/eng` fallback rules

## Validation
- Android CI run #72: success
- `:app:testDebugUnitTest`: success
- `:app:lintDebug`: success
- `:app:assembleDebug`: success
- debug APK upload: success

Closes #13