### PR TITLE
Make IME subtype drive the default keyboard mode

### DIFF
--- a/app/src/main/java/llc/slacker/openime/InputMethodSubtypePolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/InputMethodSubtypePolicy.kt
@@ -1,0 +1,40 @@
+package llc.slacker.openime
+
+internal enum class ImeSubtypeLanguage {
+    CHINESE,
+    ENGLISH,
+    UNKNOWN,
+}
+
+internal object InputMethodSubtypePolicy {
+    fun language(locale: String?): ImeSubtypeLanguage {
+        val normalized = locale.orEmpty().trim().replace('-', '_').lowercase()
+        return when {
+            normalized == "zh" || normalized.startsWith("zh_") -> ImeSubtypeLanguage.CHINESE
+            normalized == "en" || normalized.startsWith("en_") -> ImeSubtypeLanguage.ENGLISH
+            else -> ImeSubtypeLanguage.UNKNOWN
+        }
+    }
+
+    fun defaultKeyboardMode(
+        editorKind: EditorInfoAdapter.EditorKind,
+        subtypeLocale: String?,
+    ): KeyboardMode = when (editorKind) {
+        EditorInfoAdapter.EditorKind.NUMBER,
+        EditorInfoAdapter.EditorKind.DECIMAL,
+        EditorInfoAdapter.EditorKind.PHONE,
+        -> KeyboardMode.DIGITS
+
+        EditorInfoAdapter.EditorKind.EMAIL,
+        EditorInfoAdapter.EditorKind.URL,
+        EditorInfoAdapter.EditorKind.PASSWORD,
+        -> KeyboardMode.ENGLISH_26
+
+        else -> when (language(subtypeLocale)) {
+            ImeSubtypeLanguage.ENGLISH -> KeyboardMode.ENGLISH_26
+            ImeSubtypeLanguage.CHINESE,
+            ImeSubtypeLanguage.UNKNOWN,
+            -> KeyboardMode.PINYIN_26
+        }
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -10,6 +10,8 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inputmethod.InputMethodSubtype
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
@@ -176,7 +178,10 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             editorAction = attribute?.imeOptions?.and(EditorInfo.IME_MASK_ACTION)
                 ?: EditorInfo.IME_ACTION_NONE,
             passwordField = EditorInfoAdapter.isPassword(kind),
-            keyboardMode = EditorInfoAdapter.defaultKeyboardMode(kind),
+            keyboardMode = InputMethodSubtypePolicy.defaultKeyboardMode(
+                kind,
+                currentSystemSubtypeLocale(),
+            ),
             panel = Panel.NONE,
             composition = "",
             candidates = emptyList(),
@@ -185,6 +190,40 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         rime.clear()
         keyboardView?.clearAssociationCandidates()
         keyboardView?.setMode(state.keyboardMode)
+        keyboardView?.renderState(state)
+    }
+
+    override fun onCurrentInputMethodSubtypeChanged(newSubtype: InputMethodSubtype) {
+        super.onCurrentInputMethodSubtypeChanged(newSubtype)
+        if (!::gateway.isInitialized || !::rime.isInitialized) return
+
+        @Suppress("DEPRECATION")
+        val nextMode = InputMethodSubtypePolicy.defaultKeyboardMode(
+            EditorInfoAdapter.kind(state.editorInfo),
+            newSubtype.locale,
+        )
+
+        // A subtype switch changes the input language contract. Discard the old
+        // pre-edit rather than committing it under the newly selected language.
+        clearImeCompositionState(render = false)
+        gateway.cancelComposing()
+        voiceComposing = false
+        pendingVoiceCorrection = null
+        state = state.copy(
+            panel = Panel.NONE,
+            composition = "",
+            candidates = emptyList(),
+            expandedCandidates = emptyList(),
+            pinyin9Filters = emptyList(),
+            selectedPinyin9Filter = "",
+        )
+        if (keyboardView != null) {
+            // setMode clears the View-side 26/9-key buffers and synchronously
+            // feeds the effective mode back through onModeChanged().
+            keyboardView?.setMode(nextMode)
+        } else {
+            state = state.withMode(nextMode)
+        }
         keyboardView?.renderState(state)
     }
 
@@ -1131,6 +1170,12 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    @Suppress("DEPRECATION")
+    private fun currentSystemSubtypeLocale(): String? =
+        (getSystemService(INPUT_METHOD_SERVICE) as? InputMethodManager)
+            ?.currentInputMethodSubtype
+            ?.locale
 
     private fun clearImeCompositionState(render: Boolean) {
         invalidateCandidateQueries()

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -4,11 +4,13 @@
     <subtype
         android:imeSubtypeLocale="zh_CN"
         android:imeSubtypeMode="keyboard"
-        android:isAsciiCapable="false"
+        android:imeSubtypeExtraValue="AsciiCapable"
+        android:isAsciiCapable="true"
         android:label="@string/subtitle_zh" />
     <subtype
         android:imeSubtypeLocale="en_US"
         android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="AsciiCapable"
         android:isAsciiCapable="true"
         android:label="@string/subtitle_en" />
 </input-method>

--- a/app/src/test/java/llc/slacker/openime/InputMethodSubtypeMetadataTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputMethodSubtypeMetadataTest.kt
@@ -1,0 +1,29 @@
+package llc.slacker.openime
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InputMethodSubtypeMetadataTest {
+
+    private fun methodXml(): File = sequenceOf(
+        File("src/main/res/xml/method.xml"),
+        File("app/src/main/res/xml/method.xml"),
+    ).firstOrNull { it.isFile } ?: error("missing method.xml")
+
+    private fun occurrences(text: String, needle: String): Int =
+        text.split(needle).size - 1
+
+    @Test
+    fun bothDeclaredSubtypesAreAsciiCapableIncludingLegacyExtra() {
+        val xml = methodXml().readText()
+        assertTrue(xml.contains("android:imeSubtypeLocale=\"zh_CN\""))
+        assertTrue(xml.contains("android:imeSubtypeLocale=\"en_US\""))
+        assertEquals(2, occurrences(xml, "android:isAsciiCapable=\"true\""))
+        assertEquals(
+            2,
+            occurrences(xml, "android:imeSubtypeExtraValue=\"AsciiCapable\""),
+        )
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/InputMethodSubtypePolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputMethodSubtypePolicyTest.kt
@@ -1,0 +1,78 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InputMethodSubtypePolicyTest {
+
+    @Test
+    fun englishSubtypeDrivesOrdinaryTextToEnglish() {
+        assertEquals(
+            KeyboardMode.ENGLISH_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.TEXT,
+                "en_US",
+            ),
+        )
+        assertEquals(
+            KeyboardMode.ENGLISH_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.MULTILINE,
+                "en-US",
+            ),
+        )
+    }
+
+    @Test
+    fun chineseSubtypeDrivesOrdinaryTextToPinyin() {
+        assertEquals(
+            KeyboardMode.PINYIN_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.TEXT,
+                "zh_CN",
+            ),
+        )
+        assertEquals(
+            KeyboardMode.PINYIN_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.UNKNOWN,
+                "zh-CN",
+            ),
+        )
+    }
+
+    @Test
+    fun editorSafetyModesOverrideSubtypeLanguage() {
+        listOf(
+            EditorInfoAdapter.EditorKind.EMAIL,
+            EditorInfoAdapter.EditorKind.URL,
+            EditorInfoAdapter.EditorKind.PASSWORD,
+        ).forEach { kind ->
+            assertEquals(
+                KeyboardMode.ENGLISH_26,
+                InputMethodSubtypePolicy.defaultKeyboardMode(kind, "zh_CN"),
+            )
+        }
+        listOf(
+            EditorInfoAdapter.EditorKind.NUMBER,
+            EditorInfoAdapter.EditorKind.DECIMAL,
+            EditorInfoAdapter.EditorKind.PHONE,
+        ).forEach { kind ->
+            assertEquals(
+                KeyboardMode.DIGITS,
+                InputMethodSubtypePolicy.defaultKeyboardMode(kind, "en_US"),
+            )
+        }
+    }
+
+    @Test
+    fun unknownSubtypeKeepsExistingChineseDefault() {
+        assertEquals(
+            KeyboardMode.PINYIN_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.TEXT,
+                null,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- make `zh_CN` and `en_US` InputMethodSubtype participate in default keyboard selection for ordinary text editors
- preserve EditorInfo safety overrides: number/phone remain digits; password/email/URL remain ASCII English regardless of subtype
- handle live subtype changes and discard old composing/candidate/Rime state before switching language, so stale pre-edit is never committed under the new subtype
- mark both declared keyboard subtypes ASCII-capable and include the legacy `AsciiCapable` extra required for Android P and older compatibility semantics
- add pure policy tests for zh/en/default behavior and resource regression coverage for subtype metadata

## Validation
- Android CI pending
- API 29/Android 10 device-level compatibility remains covered by the repository-wide compatibility work in #37; this PR adds deterministic policy/resource coverage for the subtype contract

Closes #14