### PR TITLE
Make voice punctuation respect the editor context

### DIFF
--- a/app/src/main/java/llc/slacker/openime/EditorInfoAdapter.kt
+++ b/app/src/main/java/llc/slacker/openime/EditorInfoAdapter.kt
@@ -60,6 +60,48 @@ object EditorInfoAdapter {
         else -> KeyboardMode.PINYIN_26
     }
 
+    /**
+     * Automatic sentence punctuation is only appropriate for prose-like text.
+     * Structured fields and editors explicitly asking for no suggestions are
+     * kept literal so ASR post-processing cannot mutate searches, identifiers,
+     * addresses or command/code-style input.
+     */
+    fun allowNaturalLanguageVoicePunctuation(info: EditorInfo?): Boolean {
+        if (info == null) return false
+        when (kind(info)) {
+            EditorKind.EMAIL,
+            EditorKind.URL,
+            EditorKind.PASSWORD,
+            EditorKind.NUMBER,
+            EditorKind.DECIMAL,
+            EditorKind.PHONE,
+            EditorKind.UNKNOWN,
+            -> return false
+            EditorKind.TEXT,
+            EditorKind.MULTILINE,
+            -> Unit
+        }
+
+        if ((info.imeOptions and EditorInfo.IME_MASK_ACTION) == EditorInfo.IME_ACTION_SEARCH) {
+            return false
+        }
+
+        val inputType = info.inputType
+        if ((inputType and InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS) != 0) return false
+        val variation = inputType and InputType.TYPE_MASK_VARIATION
+        if (
+            variation in setOf(
+                InputType.TYPE_TEXT_VARIATION_FILTER,
+                InputType.TYPE_TEXT_VARIATION_PERSON_NAME,
+                InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS,
+                InputType.TYPE_TEXT_VARIATION_EMAIL_SUBJECT,
+            )
+        ) {
+            return false
+        }
+        return true
+    }
+
     fun allowCandidates(kind: EditorKind): Boolean = kind != EditorKind.PASSWORD
 
     fun isPassword(kind: EditorKind): Boolean = kind == EditorKind.PASSWORD

--- a/app/src/main/java/llc/slacker/openime/VoiceTextProcessor.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceTextProcessor.kt
@@ -1,12 +1,15 @@
 package llc.slacker.openime
 
+internal data class VoiceTextProcessingPolicy(
+    val autoTerminalPunctuation: Boolean,
+)
+
 /**
  * Fast, deterministic post-processing kept between ASR and InputConnection.
  *
  * The APK currently ships a streaming recognition model without a separate
- * punctuation model. This processor still handles the common spoken
- * punctuation words, whitespace and terminal punctuation locally, while its
- * small API leaves room for a stronger bundled punctuation/correction model.
+ * punctuation model. Spoken punctuation is interpreted conservatively and
+ * terminal punctuation is enabled only for prose-like EditorInfo contexts.
  */
 object VoiceTextProcessor {
     private val chinesePunctuation = linkedMapOf(
@@ -37,6 +40,20 @@ object VoiceTextProcessor {
     )
 
     fun process(raw: String, languageTag: String): String {
+        val service = LocalVoiceImeService.activeInstance
+        val policy = VoiceTextProcessingPolicy(
+            autoTerminalPunctuation = service?.let {
+                EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(it.currentInputEditorInfo)
+            } ?: true,
+        )
+        return process(raw, languageTag, policy)
+    }
+
+    internal fun process(
+        raw: String,
+        languageTag: String,
+        policy: VoiceTextProcessingPolicy,
+    ): String {
         var text = raw
             .replace('\n', ' ')
             .replace(Regex("\\s+"), " ")
@@ -44,24 +61,53 @@ object VoiceTextProcessor {
         if (text.isEmpty()) return ""
 
         if (languageTag.startsWith("zh", ignoreCase = true)) {
-            chinesePunctuation.forEach { (spoken, mark) ->
-                text = text.replace(spoken, mark)
-            }
+            text = replaceChineseSpokenPunctuation(text)
             // Chinese characters do not need an ASR-inserted space between
             // them, but keep spaces in embedded Latin/number phrases.
             text = text.replace(Regex("(?<=[\\u4e00-\\u9fff])\\s+(?=[\\u4e00-\\u9fff])"), "")
             text = text.replace(Regex("\\s+([，。！？；：、）》】』])"), "$1")
             text = text.replace(Regex("([，。！？；：、（《【『])\\s+"), "$1")
             text = collapsePunctuation(text)
-            if (text.length >= 4 && text.last() !in "。！？！？…") {
-                text += if (text.endsWith("吗") || text.endsWith("呢") || text.endsWith("么")) "？" else "。"
+            if (
+                policy.autoTerminalPunctuation &&
+                text.length >= 4 &&
+                text.last() !in "。！？…"
+            ) {
+                text += if (text.endsWith("吗") || text.endsWith("呢") || text.endsWith("么")) {
+                    "？"
+                } else {
+                    "。"
+                }
             }
         } else {
             englishPunctuation.forEach { (spoken, mark) ->
-                text = text.replace(Regex("(?i)(?<![A-Za-z])${Regex.escape(spoken)}(?![A-Za-z])"), mark)
+                text = text.replace(
+                    Regex("(?i)(?<![A-Za-z])${Regex.escape(spoken)}(?![A-Za-z])"),
+                    mark,
+                )
             }
             text = text.replace(Regex("\\s+([,.!?;:)])"), "$1")
             text = collapsePunctuation(text)
+        }
+        return text
+    }
+
+    /**
+     * Chinese has no reliable regex word boundary. Only standalone/pause-delimited
+     * commands are replaced in the middle of an utterance. A trailing command is
+     * also accepted because it is a common explicit dictation form. This avoids
+     * turning ordinary text such as “我喜欢句号这个名字” into punctuation.
+     */
+    private fun replaceChineseSpokenPunctuation(value: String): String {
+        var text = value
+        chinesePunctuation.forEach { (spoken, mark) ->
+            val bounded = Regex(
+                "(?<![\\p{L}\\p{N}])${Regex.escape(spoken)}(?![\\p{L}\\p{N}])",
+            )
+            text = text.replace(bounded, mark)
+            if (text.length > spoken.length && text.endsWith(spoken)) {
+                text = text.dropLast(spoken.length) + mark
+            }
         }
         return text
     }

--- a/app/src/test/java/llc/slacker/openime/VoiceTextProcessorContextTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoiceTextProcessorContextTest.kt
@@ -1,0 +1,91 @@
+package llc.slacker.openime
+
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceTextProcessorContextTest {
+
+    private val prose = VoiceTextProcessingPolicy(autoTerminalPunctuation = true)
+    private val literal = VoiceTextProcessingPolicy(autoTerminalPunctuation = false)
+
+    private fun editor(inputType: Int, action: Int = EditorInfo.IME_ACTION_NONE) =
+        EditorInfo().apply {
+            this.inputType = inputType
+            imeOptions = action
+        }
+
+    @Test
+    fun normalChineseProseKeepsAutomaticTerminalPunctuation() {
+        assertEquals("今天天气很好。", VoiceTextProcessor.process("今天天气很好", "zh-CN", prose))
+        assertEquals("你准备好了吗？", VoiceTextProcessor.process("你准备好了吗", "zh-CN", prose))
+    }
+
+    @Test
+    fun literalSearchStyleContextDoesNotAppendTerminalPunctuation() {
+        assertEquals("附近咖啡店", VoiceTextProcessor.process("附近咖啡店", "zh-CN", literal))
+    }
+
+    @Test
+    fun punctuationWordInsideOrdinaryChineseTextIsNotBlindlyReplaced() {
+        assertEquals(
+            "我喜欢句号这个名字。",
+            VoiceTextProcessor.process("我喜欢句号这个名字", "zh-CN", prose),
+        )
+    }
+
+    @Test
+    fun explicitStandaloneOrPauseDelimitedPunctuationStillWorks() {
+        assertEquals("。", VoiceTextProcessor.process("句号", "zh-CN", literal))
+        assertEquals(
+            "你好，世界。",
+            VoiceTextProcessor.process("你好 逗号 世界", "zh-CN", prose),
+        )
+        assertEquals("你好。", VoiceTextProcessor.process("你好句号", "zh-CN", literal))
+    }
+
+    @Test
+    fun editorPolicyAllowsOnlyProseLikeContexts() {
+        assertTrue(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_NORMAL),
+            ),
+        )
+        assertTrue(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE),
+            ),
+        )
+        assertFalse(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(
+                    InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_NORMAL,
+                    EditorInfo.IME_ACTION_SEARCH,
+                ),
+            ),
+        )
+        assertFalse(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS),
+            ),
+        )
+        assertFalse(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS),
+            ),
+        )
+        assertFalse(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_FILTER),
+            ),
+        )
+        assertFalse(
+            EditorInfoAdapter.allowNaturalLanguageVoicePunctuation(
+                editor(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PERSON_NAME),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- enable automatic Chinese terminal punctuation only for prose-like EditorInfo contexts
- disable automatic sentence punctuation for search actions, no-suggestions/code-like input, email/URL/password/numeric fields, filters, names, addresses, and email subjects
- replace Chinese spoken punctuation only when it is standalone/pause-delimited or an explicit trailing command instead of doing unbounded substring replacement
- preserve the existing prose experience for ordinary text and multiline editors
- add regression coverage for search-style literal input, embedded “句号” text, explicit punctuation commands, and EditorInfo policy

## Validation
- Android CI pending

Closes #33