### PR TITLE
Apply navigation bottom inset to the production IME view

### DIFF
--- a/app/src/main/java/llc/slacker/openime/ImeBottomInsetPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeBottomInsetPolicy.kt
@@ -1,0 +1,20 @@
+package llc.slacker.openime
+
+internal object ImeBottomInsetPolicy {
+    fun clampInset(reportedPx: Int, maxPx: Int): Int =
+        reportedPx.coerceAtLeast(0).coerceAtMost(maxPx.coerceAtLeast(0))
+
+    fun measuredHeight(
+        baseHeightPx: Int,
+        bottomInsetPx: Int,
+        measureMode: Int,
+        measureSizePx: Int,
+    ): Int {
+        val desired = (baseHeightPx + bottomInsetPx.coerceAtLeast(0)).coerceAtLeast(0)
+        return when (measureMode) {
+            android.view.View.MeasureSpec.AT_MOST -> minOf(desired, measureSizePx)
+            android.view.View.MeasureSpec.EXACTLY -> minOf(desired, measureSizePx)
+            else -> desired
+        }.coerceAtLeast(0)
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -1,15 +1,66 @@
 package llc.slacker.openime
 
 import android.content.Context
+import android.os.Build
+import android.view.View
+import android.view.WindowInsets
 
 /**
- * Compatibility alias. The production path uses [ImeKeyboardView] directly;
- * this class exists to keep the newer service listener contract name stable.
+ * Production wrapper around the legacy renderer. Business state still lives in
+ * the service; this layer owns window geometry that should not leak into key
+ * layout/state code.
  */
 class ImeKeyboardViewV2(
     context: Context,
     listener: Listener,
 ) : ImeKeyboardView(context, Adapter(listener)) {
+
+    private var navigationBottomInsetPx = 0
+
+    init {
+        // Insets already consumed by the IME window arrive as zero, so this
+        // adds safe area only when Android actually reports an unconsumed nav
+        // region. The value is bounded to avoid pathological OEM geometry.
+        setOnApplyWindowInsetsListener { _, insets ->
+            val reported = if (Build.VERSION.SDK_INT >= 30) {
+                insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetBottom
+            }
+            val next = ImeBottomInsetPolicy.clampInset(reported, insetDp(32))
+            if (next != navigationBottomInsetPx) {
+                navigationBottomInsetPx = next
+                requestLayout()
+            }
+            insets
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        requestApplyInsets()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        if (navigationBottomInsetPx <= 0) return
+        val targetHeight = ImeBottomInsetPolicy.measuredHeight(
+            baseHeightPx = measuredHeight,
+            bottomInsetPx = navigationBottomInsetPx,
+            measureMode = View.MeasureSpec.getMode(heightMeasureSpec),
+            measureSizePx = View.MeasureSpec.getSize(heightMeasureSpec),
+        )
+        if (targetHeight != measuredHeight) {
+            // The inherited keyboard/panel remains at its existing 296dp body
+            // height. Extra measured height becomes a bottom safe area, so the
+            // last key row is not compressed upward or covered by navigation.
+            setMeasuredDimension(measuredWidth, targetHeight)
+        }
+    }
+
+    private fun insetDp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
 
     interface Listener {
         fun onModeChanged(mode: KeyboardMode)

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -155,7 +155,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     override fun onCreateInputView(): View {
-        keyboardView = ImeKeyboardView(this, legacyAdapter)
+        keyboardView = ImeKeyboardViewV2(this, this)
         keyboardView?.setMode(state.keyboardMode)
         keyboardView?.setTheme(state.theme)
         keyboardView?.setAppearance(state.appearance)

--- a/app/src/test/java/llc/slacker/openime/ImeBottomInsetPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ImeBottomInsetPolicyTest.kt
@@ -1,0 +1,43 @@
+package llc.slacker.openime
+
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImeBottomInsetPolicyTest {
+
+    @Test
+    fun zeroInsetPreservesExistingHeight() {
+        assertEquals(
+            296,
+            ImeBottomInsetPolicy.measuredHeight(296, 0, View.MeasureSpec.UNSPECIFIED, 0),
+        )
+    }
+
+    @Test
+    fun navigationInsetAddsSafeAreaWithoutShrinkingKeyboardBody() {
+        assertEquals(
+            320,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.UNSPECIFIED, 0),
+        )
+    }
+
+    @Test
+    fun parentConstraintStillCapsTheIme() {
+        assertEquals(
+            304,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.AT_MOST, 304),
+        )
+        assertEquals(
+            300,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.EXACTLY, 300),
+        )
+    }
+
+    @Test
+    fun reportedInsetIsBoundedAndNeverNegative() {
+        assertEquals(0, ImeBottomInsetPolicy.clampInset(-5, 32))
+        assertEquals(18, ImeBottomInsetPolicy.clampInset(18, 32))
+        assertEquals(32, ImeBottomInsetPolicy.clampInset(70, 32))
+    }
+}


### PR DESCRIPTION
## Summary
- move production input-view construction to `ImeKeyboardViewV2`, which owns window-safe geometry while reusing the existing renderer and business listener contract
- consume API 30+ navigation-bar insets and the pre-30 system-window bottom inset through one bounded policy
- keep the existing 296dp keyboard/panel body intact and add any unconsumed navigation inset as bottom safe area instead of shrinking the last key row
- keep zero-inset devices at the existing measured height and respect parent AT_MOST/EXACTLY constraints
- request fresh insets when the IME view attaches, so floating/restored window geometry uses the safe measured height
- add pure regression tests for zero inset, added safe area, parent constraints, and bounded OEM values

## Dependency
- temporarily stacked on #65 / issue #14 to avoid duplicating edits in `LocalVoiceImeService`; once #14 lands this PR can be retargeted to `main`

## Validation
- Android CI pending
- policy covers both API 29-compatible `systemWindowInsetBottom` and API 30+ `WindowInsets.Type.navigationBars()` paths

Closes #34