### PR TITLE
Disable unsupported text-edit panel no-op controls

### DIFF
--- a/app/src/androidTest/java/llc/slacker/openime/TextEditControlsInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/TextEditControlsInstrumentedTest.kt
@@ -1,0 +1,95 @@
+package llc.slacker.openime
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TextEditControlsInstrumentedTest {
+
+    @get:Rule
+    val rule = ActivityScenarioRule(DebugKeyboardActivity::class.java)
+
+    @Test
+    fun unsupportedTextEditControlsAreVisiblyDisabledNotClickable() {
+        lateinit var keyboard: ImeKeyboardViewV2
+        rule.scenario.onActivity { activity ->
+            val content = activity.findViewById<ViewGroup>(android.R.id.content)
+            keyboard = ImeKeyboardViewV2(activity, NoopListener())
+            content.addView(
+                keyboard,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
+            keyboard.showPanel(Panel.TEXT_EDITOR)
+        }
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        rule.scenario.onActivity {
+            listOf("撤销", "▲", "▼").forEach { label ->
+                val control = findTextView(keyboard, label)
+                assertNotNull("missing disabled text-edit control $label", control)
+                assertFalse("$label must not remain clickable", control!!.isClickable)
+                assertFalse("$label must expose disabled state", control.isEnabled)
+                assertTrue("$label should look unavailable", control.alpha < 1f)
+            }
+
+            listOf("全选", "复制", "剪切", "粘贴", "◀", "▶").forEach { label ->
+                val control = findTextView(keyboard, label)
+                assertNotNull("missing supported text-edit control $label", control)
+                assertTrue("$label should remain clickable", control!!.isClickable)
+                assertTrue("$label should remain enabled", control.isEnabled)
+            }
+        }
+    }
+
+    private fun findTextView(root: View, label: String): TextView? {
+        if (root is TextView && root.text.toString() == label) return root
+        if (root is ViewGroup) {
+            for (index in 0 until root.childCount) {
+                findTextView(root.getChildAt(index), label)?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private class NoopListener : ImeKeyboardViewV2.Listener {
+        override fun onModeChanged(mode: KeyboardMode) = Unit
+        override fun onPanelChanged(panel: Panel) = Unit
+        override fun onCharacter(char: String) = Unit
+        override fun onBackspace() = Unit
+        override fun onClearAll() = Unit
+        override fun onSpace() = Unit
+        override fun onFloatingKeyboardChanged(floating: Boolean) = Unit
+        override fun onFloatingKeyboardDragged(deltaX: Float, deltaY: Float) = Unit
+        override fun onVoiceToggle() = Unit
+        override fun onEnter() = Unit
+        override fun onCompositionChanged(composition: String, candidates: List<String>) = Unit
+        override fun onCandidateSelected(candidate: String) = Unit
+        override fun onCompositionBackspace() = Unit
+        override fun onThemeChanged(theme: ImeTheme) = Unit
+        override fun onAppearanceChanged(appearance: ImeAppearance) = Unit
+        override fun onShiftStateChanged(state: ShiftState) = Unit
+        override fun onCandidateExpanded(open: Boolean) = Unit
+        override fun onSymbolSelected(symbol: String) = Unit
+        override fun onEmojiSelected(emoji: String) = Unit
+        override fun onTextEdit(action: String) = Unit
+        override fun onSoundChanged(enabled: Boolean) = Unit
+        override fun onHapticChanged(enabled: Boolean) = Unit
+        override fun onPopupChanged(enabled: Boolean) = Unit
+        override fun onFuzzyChanged(enabled: Boolean) = Unit
+        override fun onSkinChanged(opacity: Int, radius: Int, fontSize: Int, primaryColor: String) = Unit
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ImeBottomInsetPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeBottomInsetPolicy.kt
@@ -1,0 +1,20 @@
+package llc.slacker.openime
+
+internal object ImeBottomInsetPolicy {
+    fun clampInset(reportedPx: Int, maxPx: Int): Int =
+        reportedPx.coerceAtLeast(0).coerceAtMost(maxPx.coerceAtLeast(0))
+
+    fun measuredHeight(
+        baseHeightPx: Int,
+        bottomInsetPx: Int,
+        measureMode: Int,
+        measureSizePx: Int,
+    ): Int {
+        val desired = (baseHeightPx + bottomInsetPx.coerceAtLeast(0)).coerceAtLeast(0)
+        return when (measureMode) {
+            android.view.View.MeasureSpec.AT_MOST -> minOf(desired, measureSizePx)
+            android.view.View.MeasureSpec.EXACTLY -> minOf(desired, measureSizePx)
+            else -> desired
+        }.coerceAtLeast(0)
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -3,21 +3,33 @@ package llc.slacker.openime
 import android.content.Context
 import android.os.Build
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowInsets
+import android.widget.TextView
 
 /**
  * Production wrapper around the legacy renderer. Business state still lives in
- * the service; this layer owns window geometry that should not leak into key
- * layout/state code.
+ * the service; this layer owns window geometry and production-only capability
+ * filtering that should not leak into key layout/state code.
  */
-class ImeKeyboardViewV2(
+class ImeKeyboardViewV2 private constructor(
     context: Context,
-    listener: Listener,
-) : ImeKeyboardView(context, Adapter(listener)) {
+    private val adapter: Adapter,
+) : ImeKeyboardView(context, adapter) {
+
+    constructor(context: Context, listener: Listener) : this(context, Adapter(listener))
 
     private var navigationBottomInsetPx = 0
 
     init {
+        adapter.afterPanelChanged = { panel ->
+            if (panel == Panel.TEXT_EDITOR) {
+                // The legacy renderer invokes onPanelChanged before renderPanel,
+                // so defer capability filtering until the panel children exist.
+                post { disableUnsupportedTextEditControls() }
+            }
+        }
+
         // Insets already consumed by the IME window arrive as zero, so this
         // adds safe area only when Android actually reports an unconsumed nav
         // region. The value is bounded to avoid pathological OEM geometry.
@@ -57,6 +69,21 @@ class ImeKeyboardViewV2(
             // last key row is not compressed upward or covered by navigation.
             setMeasuredDimension(measuredWidth, targetHeight)
         }
+    }
+
+    private fun disableUnsupportedTextEditControls() {
+        fun visit(view: View) {
+            if (view is TextView && TextEditControlPolicy.isUnavailableLabel(view.text.toString())) {
+                view.isEnabled = false
+                view.isClickable = false
+                view.alpha = 0.38f
+                view.contentDescription = "${view.text}（当前编辑器暂不支持）"
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) visit(view.getChildAt(index))
+            }
+        }
+        visit(this)
     }
 
     private fun insetDp(value: Int): Int =
@@ -114,8 +141,13 @@ class ImeKeyboardViewV2(
     }
 
     private class Adapter(private val delegate: Listener) : ImeKeyboardView.Listener {
+        var afterPanelChanged: ((Panel) -> Unit)? = null
+
         override fun onModeChanged(mode: KeyboardMode) = delegate.onModeChanged(mode)
-        override fun onPanelChanged(panel: Panel) = delegate.onPanelChanged(panel)
+        override fun onPanelChanged(panel: Panel) {
+            delegate.onPanelChanged(panel)
+            afterPanelChanged?.invoke(panel)
+        }
         override fun onCharacter(char: String) = delegate.onCharacter(char)
         override fun onBackspace() = delegate.onBackspace()
         override fun onClearAll() = delegate.onClearAll()

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -1,15 +1,66 @@
 package llc.slacker.openime
 
 import android.content.Context
+import android.os.Build
+import android.view.View
+import android.view.WindowInsets
 
 /**
- * Compatibility alias. The production path uses [ImeKeyboardView] directly;
- * this class exists to keep the newer service listener contract name stable.
+ * Production wrapper around the legacy renderer. Business state still lives in
+ * the service; this layer owns window geometry that should not leak into key
+ * layout/state code.
  */
 class ImeKeyboardViewV2(
     context: Context,
     listener: Listener,
 ) : ImeKeyboardView(context, Adapter(listener)) {
+
+    private var navigationBottomInsetPx = 0
+
+    init {
+        // Insets already consumed by the IME window arrive as zero, so this
+        // adds safe area only when Android actually reports an unconsumed nav
+        // region. The value is bounded to avoid pathological OEM geometry.
+        setOnApplyWindowInsetsListener { _, insets ->
+            val reported = if (Build.VERSION.SDK_INT >= 30) {
+                insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetBottom
+            }
+            val next = ImeBottomInsetPolicy.clampInset(reported, insetDp(32))
+            if (next != navigationBottomInsetPx) {
+                navigationBottomInsetPx = next
+                requestLayout()
+            }
+            insets
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        requestApplyInsets()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        if (navigationBottomInsetPx <= 0) return
+        val targetHeight = ImeBottomInsetPolicy.measuredHeight(
+            baseHeightPx = measuredHeight,
+            bottomInsetPx = navigationBottomInsetPx,
+            measureMode = View.MeasureSpec.getMode(heightMeasureSpec),
+            measureSizePx = View.MeasureSpec.getSize(heightMeasureSpec),
+        )
+        if (targetHeight != measuredHeight) {
+            // The inherited keyboard/panel remains at its existing 296dp body
+            // height. Extra measured height becomes a bottom safe area, so the
+            // last key row is not compressed upward or covered by navigation.
+            setMeasuredDimension(measuredWidth, targetHeight)
+        }
+    }
+
+    private fun insetDp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
 
     interface Listener {
         fun onModeChanged(mode: KeyboardMode)

--- a/app/src/main/java/llc/slacker/openime/InputMethodSubtypePolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/InputMethodSubtypePolicy.kt
@@ -1,0 +1,40 @@
+package llc.slacker.openime
+
+internal enum class ImeSubtypeLanguage {
+    CHINESE,
+    ENGLISH,
+    UNKNOWN,
+}
+
+internal object InputMethodSubtypePolicy {
+    fun language(locale: String?): ImeSubtypeLanguage {
+        val normalized = locale.orEmpty().trim().replace('-', '_').lowercase()
+        return when {
+            normalized == "zh" || normalized.startsWith("zh_") -> ImeSubtypeLanguage.CHINESE
+            normalized == "en" || normalized.startsWith("en_") -> ImeSubtypeLanguage.ENGLISH
+            else -> ImeSubtypeLanguage.UNKNOWN
+        }
+    }
+
+    fun defaultKeyboardMode(
+        editorKind: EditorInfoAdapter.EditorKind,
+        subtypeLocale: String?,
+    ): KeyboardMode = when (editorKind) {
+        EditorInfoAdapter.EditorKind.NUMBER,
+        EditorInfoAdapter.EditorKind.DECIMAL,
+        EditorInfoAdapter.EditorKind.PHONE,
+        -> KeyboardMode.DIGITS
+
+        EditorInfoAdapter.EditorKind.EMAIL,
+        EditorInfoAdapter.EditorKind.URL,
+        EditorInfoAdapter.EditorKind.PASSWORD,
+        -> KeyboardMode.ENGLISH_26
+
+        else -> when (language(subtypeLocale)) {
+            ImeSubtypeLanguage.ENGLISH -> KeyboardMode.ENGLISH_26
+            ImeSubtypeLanguage.CHINESE,
+            ImeSubtypeLanguage.UNKNOWN,
+            -> KeyboardMode.PINYIN_26
+        }
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -10,6 +10,8 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inputmethod.InputMethodSubtype
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
@@ -176,7 +178,10 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             editorAction = attribute?.imeOptions?.and(EditorInfo.IME_MASK_ACTION)
                 ?: EditorInfo.IME_ACTION_NONE,
             passwordField = EditorInfoAdapter.isPassword(kind),
-            keyboardMode = EditorInfoAdapter.defaultKeyboardMode(kind),
+            keyboardMode = InputMethodSubtypePolicy.defaultKeyboardMode(
+                kind,
+                currentSystemSubtypeLocale(),
+            ),
             panel = Panel.NONE,
             composition = "",
             candidates = emptyList(),
@@ -185,6 +190,40 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         rime.clear()
         keyboardView?.clearAssociationCandidates()
         keyboardView?.setMode(state.keyboardMode)
+        keyboardView?.renderState(state)
+    }
+
+    override fun onCurrentInputMethodSubtypeChanged(newSubtype: InputMethodSubtype) {
+        super.onCurrentInputMethodSubtypeChanged(newSubtype)
+        if (!::gateway.isInitialized || !::rime.isInitialized) return
+
+        @Suppress("DEPRECATION")
+        val nextMode = InputMethodSubtypePolicy.defaultKeyboardMode(
+            EditorInfoAdapter.kind(state.editorInfo),
+            newSubtype.locale,
+        )
+
+        // A subtype switch changes the input language contract. Discard the old
+        // pre-edit rather than committing it under the newly selected language.
+        clearImeCompositionState(render = false)
+        gateway.cancelComposing()
+        voiceComposing = false
+        pendingVoiceCorrection = null
+        state = state.copy(
+            panel = Panel.NONE,
+            composition = "",
+            candidates = emptyList(),
+            expandedCandidates = emptyList(),
+            pinyin9Filters = emptyList(),
+            selectedPinyin9Filter = "",
+        )
+        if (keyboardView != null) {
+            // setMode clears the View-side 26/9-key buffers and synchronously
+            // feeds the effective mode back through onModeChanged().
+            keyboardView?.setMode(nextMode)
+        } else {
+            state = state.withMode(nextMode)
+        }
         keyboardView?.renderState(state)
     }
 
@@ -1131,6 +1170,12 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    @Suppress("DEPRECATION")
+    private fun currentSystemSubtypeLocale(): String? =
+        (getSystemService(INPUT_METHOD_SERVICE) as? InputMethodManager)
+            ?.currentInputMethodSubtype
+            ?.locale
 
     private fun clearImeCompositionState(render: Boolean) {
         invalidateCandidateQueries()

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -155,7 +155,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     override fun onCreateInputView(): View {
-        keyboardView = ImeKeyboardView(this, legacyAdapter)
+        keyboardView = ImeKeyboardViewV2(this, this)
         keyboardView?.setMode(state.keyboardMode)
         keyboardView?.setTheme(state.theme)
         keyboardView?.setAppearance(state.appearance)

--- a/app/src/main/java/llc/slacker/openime/TextEditControlPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/TextEditControlPolicy.kt
@@ -1,0 +1,12 @@
+package llc.slacker.openime
+
+/**
+ * Controls that the legacy text-edit panel renders but cannot implement
+ * reliably across arbitrary target editors. Production keeps them visible as
+ * disabled affordances rather than exposing clickable no-ops.
+ */
+internal object TextEditControlPolicy {
+    private val unavailableLabels = setOf("撤销", "▲", "▼")
+
+    fun isUnavailableLabel(label: String): Boolean = label in unavailableLabels
+}

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -4,11 +4,13 @@
     <subtype
         android:imeSubtypeLocale="zh_CN"
         android:imeSubtypeMode="keyboard"
-        android:isAsciiCapable="false"
+        android:imeSubtypeExtraValue="AsciiCapable"
+        android:isAsciiCapable="true"
         android:label="@string/subtitle_zh" />
     <subtype
         android:imeSubtypeLocale="en_US"
         android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="AsciiCapable"
         android:isAsciiCapable="true"
         android:label="@string/subtitle_en" />
 </input-method>

--- a/app/src/test/java/llc/slacker/openime/ImeBottomInsetPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ImeBottomInsetPolicyTest.kt
@@ -1,0 +1,43 @@
+package llc.slacker.openime
+
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImeBottomInsetPolicyTest {
+
+    @Test
+    fun zeroInsetPreservesExistingHeight() {
+        assertEquals(
+            296,
+            ImeBottomInsetPolicy.measuredHeight(296, 0, View.MeasureSpec.UNSPECIFIED, 0),
+        )
+    }
+
+    @Test
+    fun navigationInsetAddsSafeAreaWithoutShrinkingKeyboardBody() {
+        assertEquals(
+            320,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.UNSPECIFIED, 0),
+        )
+    }
+
+    @Test
+    fun parentConstraintStillCapsTheIme() {
+        assertEquals(
+            304,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.AT_MOST, 304),
+        )
+        assertEquals(
+            300,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.EXACTLY, 300),
+        )
+    }
+
+    @Test
+    fun reportedInsetIsBoundedAndNeverNegative() {
+        assertEquals(0, ImeBottomInsetPolicy.clampInset(-5, 32))
+        assertEquals(18, ImeBottomInsetPolicy.clampInset(18, 32))
+        assertEquals(32, ImeBottomInsetPolicy.clampInset(70, 32))
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/InputMethodSubtypeMetadataTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputMethodSubtypeMetadataTest.kt
@@ -12,15 +12,18 @@ class InputMethodSubtypeMetadataTest {
         File("app/src/main/res/xml/method.xml"),
     ).firstOrNull { it.isFile } ?: error("missing method.xml")
 
+    private fun occurrences(text: String, needle: String): Int =
+        text.split(needle).size - 1
+
     @Test
     fun bothDeclaredSubtypesAreAsciiCapableIncludingLegacyExtra() {
         val xml = methodXml().readText()
         assertTrue(xml.contains("android:imeSubtypeLocale=\"zh_CN\""))
         assertTrue(xml.contains("android:imeSubtypeLocale=\"en_US\""))
-        assertEquals(2, Regex("android:isAsciiCapable=\\\"true\\\"").findAll(xml).count())
+        assertEquals(2, occurrences(xml, "android:isAsciiCapable=\"true\""))
         assertEquals(
             2,
-            Regex("android:imeSubtypeExtraValue=\\\"AsciiCapable\\\"").findAll(xml).count(),
+            occurrences(xml, "android:imeSubtypeExtraValue=\"AsciiCapable\""),
         )
     }
 }

--- a/app/src/test/java/llc/slacker/openime/InputMethodSubtypeMetadataTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputMethodSubtypeMetadataTest.kt
@@ -1,0 +1,26 @@
+package llc.slacker.openime
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InputMethodSubtypeMetadataTest {
+
+    private fun methodXml(): File = sequenceOf(
+        File("src/main/res/xml/method.xml"),
+        File("app/src/main/res/xml/method.xml"),
+    ).firstOrNull { it.isFile } ?: error("missing method.xml")
+
+    @Test
+    fun bothDeclaredSubtypesAreAsciiCapableIncludingLegacyExtra() {
+        val xml = methodXml().readText()
+        assertTrue(xml.contains("android:imeSubtypeLocale=\"zh_CN\""))
+        assertTrue(xml.contains("android:imeSubtypeLocale=\"en_US\""))
+        assertEquals(2, Regex("android:isAsciiCapable=\\\"true\\\"").findAll(xml).count())
+        assertEquals(
+            2,
+            Regex("android:imeSubtypeExtraValue=\\\"AsciiCapable\\\"").findAll(xml).count(),
+        )
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/InputMethodSubtypePolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputMethodSubtypePolicyTest.kt
@@ -1,0 +1,78 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InputMethodSubtypePolicyTest {
+
+    @Test
+    fun englishSubtypeDrivesOrdinaryTextToEnglish() {
+        assertEquals(
+            KeyboardMode.ENGLISH_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.TEXT,
+                "en_US",
+            ),
+        )
+        assertEquals(
+            KeyboardMode.ENGLISH_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.MULTILINE,
+                "en-US",
+            ),
+        )
+    }
+
+    @Test
+    fun chineseSubtypeDrivesOrdinaryTextToPinyin() {
+        assertEquals(
+            KeyboardMode.PINYIN_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.TEXT,
+                "zh_CN",
+            ),
+        )
+        assertEquals(
+            KeyboardMode.PINYIN_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.UNKNOWN,
+                "zh-CN",
+            ),
+        )
+    }
+
+    @Test
+    fun editorSafetyModesOverrideSubtypeLanguage() {
+        listOf(
+            EditorInfoAdapter.EditorKind.EMAIL,
+            EditorInfoAdapter.EditorKind.URL,
+            EditorInfoAdapter.EditorKind.PASSWORD,
+        ).forEach { kind ->
+            assertEquals(
+                KeyboardMode.ENGLISH_26,
+                InputMethodSubtypePolicy.defaultKeyboardMode(kind, "zh_CN"),
+            )
+        }
+        listOf(
+            EditorInfoAdapter.EditorKind.NUMBER,
+            EditorInfoAdapter.EditorKind.DECIMAL,
+            EditorInfoAdapter.EditorKind.PHONE,
+        ).forEach { kind ->
+            assertEquals(
+                KeyboardMode.DIGITS,
+                InputMethodSubtypePolicy.defaultKeyboardMode(kind, "en_US"),
+            )
+        }
+    }
+
+    @Test
+    fun unknownSubtypeKeepsExistingChineseDefault() {
+        assertEquals(
+            KeyboardMode.PINYIN_26,
+            InputMethodSubtypePolicy.defaultKeyboardMode(
+                EditorInfoAdapter.EditorKind.TEXT,
+                null,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/TextEditControlPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/TextEditControlPolicyTest.kt
@@ -1,0 +1,18 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TextEditControlPolicyTest {
+
+    @Test
+    fun onlyKnownNoOpControlsAreUnavailable() {
+        listOf("撤销", "▲", "▼").forEach { label ->
+            assertTrue(label, TextEditControlPolicy.isUnavailableLabel(label))
+        }
+        listOf("全选", "复制", "剪切", "粘贴", "◀", "▶").forEach { label ->
+            assertFalse(label, TextEditControlPolicy.isUnavailableLabel(label))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep the legacy text-edit panel layout intact but make `撤销`, `▲`, and `▼` visibly disabled and non-clickable in the production `ImeKeyboardViewV2`
- apply the filtering only after the text-edit panel has actually rendered, so supported controls are untouched
- leave `全选`, `复制`, `剪切`, `粘贴`, `◀`, and `▶` enabled and clickable
- centralize the unavailable-control labels in a small policy so the production wrapper and tests share the same contract
- add host coverage for the capability policy and instrumentation coverage that mounts the production V2 view, opens the text-edit panel, and verifies disabled vs supported controls

## Dependency
- stacked on #67 / issue #34 because production capability filtering lives in the V2 wrapper introduced there

## Validation
- Android CI pending

Closes #20