### PR TITLE
Fix priority user-facing IME behavior

### DIFF
--- a/app/src/androidTest/java/llc/slacker/openime/ClipboardRetentionInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/ClipboardRetentionInstrumentedTest.kt
@@ -1,0 +1,101 @@
+package llc.slacker.openime
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ClipboardRetentionInstrumentedTest {
+
+    @get:Rule
+    val rule = ActivityScenarioRule(DebugKeyboardActivity::class.java)
+
+    @Test
+    fun clearButtonsMutatePersistentHistoryWithoutTouchingPinnedUntilRequested() {
+        lateinit var keyboard: ImeKeyboardViewV2
+        rule.scenario.onActivity { activity ->
+            val clipboard = activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText("test", ""))
+            ClipboardHistoryRepository.clearAll(activity)
+            ClipboardHistoryRepository.add(activity, "keep pinned")
+            ClipboardHistoryRepository.togglePin(activity, "keep pinned")
+            ClipboardHistoryRepository.add(activity, "remove normal")
+
+            val content = activity.findViewById<ViewGroup>(android.R.id.content)
+            keyboard = ImeKeyboardViewV2(activity, NoopListener())
+            content.addView(
+                keyboard,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
+            keyboard.showPanel(Panel.CLIPBOARD)
+        }
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        rule.scenario.onActivity { activity ->
+            val clearUnpinned = findTextView(keyboard, "清除未固定")
+            assertNotNull(clearUnpinned)
+            clearUnpinned!!.performClick()
+            val remaining = ClipboardHistoryRepository.load(activity)
+            assertEquals(listOf("keep pinned"), remaining.map { it.text })
+            assertEquals(true, remaining.single().pinned)
+
+            val clearAll = findTextView(keyboard, "清空全部")
+            assertNotNull(clearAll)
+            clearAll!!.performClick()
+            assertEquals(emptyList<ClipboardEntry>(), ClipboardHistoryRepository.load(activity))
+        }
+    }
+
+    private fun findTextView(root: View, label: String): TextView? {
+        if (root is TextView && root.text.toString() == label) return root
+        if (root is ViewGroup) {
+            for (index in 0 until root.childCount) {
+                findTextView(root.getChildAt(index), label)?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private class NoopListener : ImeKeyboardViewV2.Listener {
+        override fun onModeChanged(mode: KeyboardMode) = Unit
+        override fun onPanelChanged(panel: Panel) = Unit
+        override fun onCharacter(char: String) = Unit
+        override fun onBackspace() = Unit
+        override fun onClearAll() = Unit
+        override fun onSpace() = Unit
+        override fun onFloatingKeyboardChanged(floating: Boolean) = Unit
+        override fun onFloatingKeyboardDragged(deltaX: Float, deltaY: Float) = Unit
+        override fun onVoiceToggle() = Unit
+        override fun onEnter() = Unit
+        override fun onCompositionChanged(composition: String, candidates: List<String>) = Unit
+        override fun onCandidateSelected(candidate: String) = Unit
+        override fun onCompositionBackspace() = Unit
+        override fun onThemeChanged(theme: ImeTheme) = Unit
+        override fun onAppearanceChanged(appearance: ImeAppearance) = Unit
+        override fun onShiftStateChanged(state: ShiftState) = Unit
+        override fun onCandidateExpanded(open: Boolean) = Unit
+        override fun onSymbolSelected(symbol: String) = Unit
+        override fun onEmojiSelected(emoji: String) = Unit
+        override fun onTextEdit(action: String) = Unit
+        override fun onSoundChanged(enabled: Boolean) = Unit
+        override fun onHapticChanged(enabled: Boolean) = Unit
+        override fun onPopupChanged(enabled: Boolean) = Unit
+        override fun onFuzzyChanged(enabled: Boolean) = Unit
+        override fun onSkinChanged(opacity: Int, radius: Int, fontSize: Int, primaryColor: String) = Unit
+    }
+}

--- a/app/src/androidTest/java/llc/slacker/openime/TextEditControlsInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/TextEditControlsInstrumentedTest.kt
@@ -1,0 +1,95 @@
+package llc.slacker.openime
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TextEditControlsInstrumentedTest {
+
+    @get:Rule
+    val rule = ActivityScenarioRule(DebugKeyboardActivity::class.java)
+
+    @Test
+    fun unsupportedTextEditControlsAreVisiblyDisabledNotClickable() {
+        lateinit var keyboard: ImeKeyboardViewV2
+        rule.scenario.onActivity { activity ->
+            val content = activity.findViewById<ViewGroup>(android.R.id.content)
+            keyboard = ImeKeyboardViewV2(activity, NoopListener())
+            content.addView(
+                keyboard,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
+            keyboard.showPanel(Panel.TEXT_EDITOR)
+        }
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        rule.scenario.onActivity {
+            listOf("撤销", "▲", "▼").forEach { label ->
+                val control = findTextView(keyboard, label)
+                assertNotNull("missing disabled text-edit control $label", control)
+                assertFalse("$label must not remain clickable", control!!.isClickable)
+                assertFalse("$label must expose disabled state", control.isEnabled)
+                assertTrue("$label should look unavailable", control.alpha < 1f)
+            }
+
+            listOf("全选", "复制", "剪切", "粘贴", "◀", "▶").forEach { label ->
+                val control = findTextView(keyboard, label)
+                assertNotNull("missing supported text-edit control $label", control)
+                assertTrue("$label should remain clickable", control!!.isClickable)
+                assertTrue("$label should remain enabled", control.isEnabled)
+            }
+        }
+    }
+
+    private fun findTextView(root: View, label: String): TextView? {
+        if (root is TextView && root.text.toString() == label) return root
+        if (root is ViewGroup) {
+            for (index in 0 until root.childCount) {
+                findTextView(root.getChildAt(index), label)?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private class NoopListener : ImeKeyboardViewV2.Listener {
+        override fun onModeChanged(mode: KeyboardMode) = Unit
+        override fun onPanelChanged(panel: Panel) = Unit
+        override fun onCharacter(char: String) = Unit
+        override fun onBackspace() = Unit
+        override fun onClearAll() = Unit
+        override fun onSpace() = Unit
+        override fun onFloatingKeyboardChanged(floating: Boolean) = Unit
+        override fun onFloatingKeyboardDragged(deltaX: Float, deltaY: Float) = Unit
+        override fun onVoiceToggle() = Unit
+        override fun onEnter() = Unit
+        override fun onCompositionChanged(composition: String, candidates: List<String>) = Unit
+        override fun onCandidateSelected(candidate: String) = Unit
+        override fun onCompositionBackspace() = Unit
+        override fun onThemeChanged(theme: ImeTheme) = Unit
+        override fun onAppearanceChanged(appearance: ImeAppearance) = Unit
+        override fun onShiftStateChanged(state: ShiftState) = Unit
+        override fun onCandidateExpanded(open: Boolean) = Unit
+        override fun onSymbolSelected(symbol: String) = Unit
+        override fun onEmojiSelected(emoji: String) = Unit
+        override fun onTextEdit(action: String) = Unit
+        override fun onSoundChanged(enabled: Boolean) = Unit
+        override fun onHapticChanged(enabled: Boolean) = Unit
+        override fun onPopupChanged(enabled: Boolean) = Unit
+        override fun onFuzzyChanged(enabled: Boolean) = Unit
+        override fun onSkinChanged(opacity: Int, radius: Int, fontSize: Int, primaryColor: String) = Unit
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ClipboardHistoryRepository.kt
+++ b/app/src/main/java/llc/slacker/openime/ClipboardHistoryRepository.kt
@@ -33,10 +33,27 @@ internal object ClipboardPrivacyPolicy {
             (imeOptions and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING) == 0
 }
 
+internal object ClipboardRetentionPolicy {
+    const val UNPINNED_TTL_MS = 24L * 60L * 60L * 1_000L
+
+    fun retain(entry: ClipboardEntry, nowMs: Long): Boolean {
+        if (entry.pinned) return true
+        if (entry.timestamp <= 0L) return false
+        val age = nowMs - entry.timestamp
+        // Keep future timestamps when the wall clock moved backwards; they
+        // become eligible for expiry naturally after real time catches up.
+        return age < 0L || age <= UNPINNED_TTL_MS
+    }
+
+    fun prune(entries: List<ClipboardEntry>, nowMs: Long): List<ClipboardEntry> =
+        entries.filter { retain(it, nowMs) }
+}
+
 /**
  * Tiny persistent clipboard history. Clipboard capture is best-effort; no
  * clipboard content is logged. Password and no-personalized-learning editors
- * cannot read from or write to the persistent history at all.
+ * cannot read from or write to the persistent history at all. Unpinned items
+ * expire after 24 hours; pinned items remain until the user removes them.
  */
 object ClipboardHistoryRepository {
     private const val PREFS = "ime_clipboard_history"
@@ -97,6 +114,16 @@ object ClipboardHistoryRepository {
         save(context, loadStored(context).filterNot { it.text == text })
     }
 
+    fun clearUnpinned(context: Context) {
+        if (!canUsePersistentHistory(context)) return
+        save(context, loadStored(context).filter { it.pinned })
+    }
+
+    fun clearAll(context: Context) {
+        if (!canUsePersistentHistory(context)) return
+        save(context, emptyList())
+    }
+
     private fun canUsePersistentHistory(context: Context): Boolean {
         val service = context as? InputMethodService ?: return true
         val editorInfo = service.currentInputEditorInfo ?: return true
@@ -109,7 +136,7 @@ object ClipboardHistoryRepository {
     private fun loadStored(context: Context): List<ClipboardEntry> {
         val raw = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             .getString(KEY_ITEMS, "[]") ?: "[]"
-        return runCatching {
+        val parsed = runCatching {
             val arr = JSONArray(raw)
             buildList {
                 for (i in 0 until arr.length()) {
@@ -124,6 +151,9 @@ object ClipboardHistoryRepository {
                 }
             }
         }.getOrElse { emptyList() }
+        val retained = ClipboardRetentionPolicy.prune(parsed, System.currentTimeMillis())
+        if (retained.size != parsed.size) save(context, retained)
+        return retained
     }
 
     private fun save(context: Context, items: List<ClipboardEntry>) {

--- a/app/src/main/java/llc/slacker/openime/ImeBottomInsetPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeBottomInsetPolicy.kt
@@ -1,0 +1,20 @@
+package llc.slacker.openime
+
+internal object ImeBottomInsetPolicy {
+    fun clampInset(reportedPx: Int, maxPx: Int): Int =
+        reportedPx.coerceAtLeast(0).coerceAtMost(maxPx.coerceAtLeast(0))
+
+    fun measuredHeight(
+        baseHeightPx: Int,
+        bottomInsetPx: Int,
+        measureMode: Int,
+        measureSizePx: Int,
+    ): Int {
+        val desired = (baseHeightPx + bottomInsetPx.coerceAtLeast(0)).coerceAtLeast(0)
+        return when (measureMode) {
+            android.view.View.MeasureSpec.AT_MOST -> minOf(desired, measureSizePx)
+            android.view.View.MeasureSpec.EXACTLY -> minOf(desired, measureSizePx)
+            else -> desired
+        }.coerceAtLeast(0)
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -1,15 +1,180 @@
 package llc.slacker.openime
 
 import android.content.Context
+import android.os.Build
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowInsets
+import android.widget.LinearLayout
+import android.widget.TextView
 
 /**
- * Compatibility alias. The production path uses [ImeKeyboardView] directly;
- * this class exists to keep the newer service listener contract name stable.
+ * Production wrapper around the legacy renderer. Business state still lives in
+ * the service; this layer owns window geometry and production-only capability
+ * filtering that should not leak into key layout/state code.
  */
-class ImeKeyboardViewV2(
+class ImeKeyboardViewV2 private constructor(
     context: Context,
-    listener: Listener,
-) : ImeKeyboardView(context, Adapter(listener)) {
+    private val adapter: Adapter,
+) : ImeKeyboardView(context, adapter) {
+
+    constructor(context: Context, listener: Listener) : this(context, Adapter(listener))
+
+    private var navigationBottomInsetPx = 0
+
+    init {
+        adapter.afterPanelChanged = { panel ->
+            when (panel) {
+                Panel.TEXT_EDITOR -> {
+                    // The legacy renderer invokes onPanelChanged before renderPanel,
+                    // so defer capability filtering until the panel children exist.
+                    post { disableUnsupportedTextEditControls() }
+                }
+                Panel.CLIPBOARD -> post { decorateClipboardRetentionControls() }
+                else -> Unit
+            }
+        }
+
+        // Insets already consumed by the IME window arrive as zero, so this
+        // adds safe area only when Android actually reports an unconsumed nav
+        // region. The value is bounded to avoid pathological OEM geometry.
+        setOnApplyWindowInsetsListener { _, insets ->
+            val reported = if (Build.VERSION.SDK_INT >= 30) {
+                insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetBottom
+            }
+            val next = ImeBottomInsetPolicy.clampInset(reported, insetDp(32))
+            if (next != navigationBottomInsetPx) {
+                navigationBottomInsetPx = next
+                requestLayout()
+            }
+            insets
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        requestApplyInsets()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        if (navigationBottomInsetPx <= 0) return
+        val targetHeight = ImeBottomInsetPolicy.measuredHeight(
+            baseHeightPx = measuredHeight,
+            bottomInsetPx = navigationBottomInsetPx,
+            measureMode = View.MeasureSpec.getMode(heightMeasureSpec),
+            measureSizePx = View.MeasureSpec.getSize(heightMeasureSpec),
+        )
+        if (targetHeight != measuredHeight) {
+            // The inherited keyboard/panel remains at its existing 296dp body
+            // height. Extra measured height becomes a bottom safe area, so the
+            // last key row is not compressed upward or covered by navigation.
+            setMeasuredDimension(measuredWidth, targetHeight)
+        }
+    }
+
+    private fun disableUnsupportedTextEditControls() {
+        fun visit(view: View) {
+            if (view is TextView && TextEditControlPolicy.isUnavailableLabel(view.text.toString())) {
+                view.isEnabled = false
+                view.isClickable = false
+                view.alpha = 0.38f
+                view.contentDescription = "${view.text}（当前编辑器暂不支持）"
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) visit(view.getChildAt(index))
+            }
+        }
+        visit(this)
+    }
+
+    private fun decorateClipboardRetentionControls() {
+        if (findViewWithTag<View>("quick-phrase-add") != null) return
+        val body = findViewWithTag<LinearLayout>("clipboard-panel") ?: return
+        if (body.findViewWithTag<View>("clipboard-retention-actions") != null) return
+        if (ClipboardHistoryRepository.load(context).isEmpty()) return
+
+        val row = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            tag = "clipboard-retention-actions"
+        }
+        row.addView(
+            clipboardRetentionAction("清除未固定") {
+                ClipboardHistoryRepository.clearUnpinned(context)
+                hideClipboardCards(includePinned = false)
+                if (ClipboardHistoryRepository.load(context).isEmpty()) row.visibility = View.GONE
+            },
+            LinearLayout.LayoutParams(0, insetDp(36), 1f).apply { marginEnd = insetDp(6) },
+        )
+        row.addView(
+            clipboardRetentionAction("清空全部") {
+                ClipboardHistoryRepository.clearAll(context)
+                hideClipboardCards(includePinned = true)
+                row.visibility = View.GONE
+            },
+            LinearLayout.LayoutParams(0, insetDp(36), 1f),
+        )
+        body.addView(
+            row,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                insetDp(36),
+            ).apply { topMargin = insetDp(6) },
+        )
+    }
+
+    private fun clipboardRetentionAction(label: String, onClick: () -> Unit): TextView =
+        TextView(context).apply {
+            text = label
+            textSize = 12f
+            gravity = Gravity.CENTER
+            isClickable = true
+            isFocusable = true
+            contentDescription = label
+            val backgroundValue = TypedValue()
+            if (
+                context.theme.resolveAttribute(
+                    android.R.attr.selectableItemBackground,
+                    backgroundValue,
+                    true,
+                ) && backgroundValue.resourceId != 0
+            ) {
+                setBackgroundResource(backgroundValue.resourceId)
+            }
+            setOnClickListener { onClick() }
+        }
+
+    private fun hideClipboardCards(includePinned: Boolean) {
+        fun containsPinnedMarker(view: View): Boolean {
+            if (view is TextView && view.text.toString() == "已置顶") return true
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) {
+                    if (containsPinnedMarker(view.getChildAt(index))) return true
+                }
+            }
+            return false
+        }
+
+        fun visit(view: View) {
+            if (view.tag == "clip-card") {
+                if (includePinned || !containsPinnedMarker(view)) view.visibility = View.GONE
+                return
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) visit(view.getChildAt(index))
+            }
+        }
+        visit(this)
+    }
+
+    private fun insetDp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
 
     interface Listener {
         fun onModeChanged(mode: KeyboardMode)
@@ -63,8 +228,13 @@ class ImeKeyboardViewV2(
     }
 
     private class Adapter(private val delegate: Listener) : ImeKeyboardView.Listener {
+        var afterPanelChanged: ((Panel) -> Unit)? = null
+
         override fun onModeChanged(mode: KeyboardMode) = delegate.onModeChanged(mode)
-        override fun onPanelChanged(panel: Panel) = delegate.onPanelChanged(panel)
+        override fun onPanelChanged(panel: Panel) {
+            delegate.onPanelChanged(panel)
+            afterPanelChanged?.invoke(panel)
+        }
         override fun onCharacter(char: String) = delegate.onCharacter(char)
         override fun onBackspace() = delegate.onBackspace()
         override fun onClearAll() = delegate.onClearAll()

--- a/app/src/main/java/llc/slacker/openime/LocalAudioVoiceBackend.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalAudioVoiceBackend.kt
@@ -141,6 +141,10 @@ interface StreamingVoiceRuntimeProvider {
     fun isExpectedAvailable(): Boolean
 
     fun awaitRuntime(): StreamingEmbeddedVoiceModelRuntime?
+
+    /** Trace token created by the service before this voice gesture starts. */
+    fun performanceTraceToken(): VoicePerformanceTrace.Token? =
+        VoicePerformanceTrace.currentTokenForBackend()
 }
 
 private class FixedStreamingVoiceRuntimeProvider(
@@ -193,10 +197,11 @@ class LocalAudioVoiceBackend(
             return
         }
 
+        val traceToken = runtimeProvider.performanceTraceToken() ?: VoicePerformanceTrace.begin()
         val generation = startGeneration.incrementAndGet()
         stopRequestedGeneration.set(-1L)
         startExecutor.execute {
-            initializeSession(generation, languageTag, events)
+            initializeSession(generation, languageTag, events, traceToken)
         }
     }
 
@@ -205,14 +210,15 @@ class LocalAudioVoiceBackend(
         generation: Long,
         languageTag: String,
         events: VoiceRecognitionEvents,
+        traceToken: VoicePerformanceTrace.Token,
     ) {
-
         val minBufferBytes = AudioRecord.getMinBufferSize(
             LocalVoiceAudioSpec.SAMPLE_RATE,
             LocalVoiceAudioSpec.CHANNEL_MASK,
             LocalVoiceAudioSpec.ENCODING,
         )
         if (minBufferBytes <= 0) {
+            VoicePerformanceTrace.finish(traceToken, 0L, failed = true)
             events.onError("设备不支持 16kHz 麦克风采集")
             return
         }
@@ -240,12 +246,14 @@ class LocalAudioVoiceBackend(
                 .build()
         }.getOrElse {
             routeSession.close()
+            VoicePerformanceTrace.finish(traceToken, 0L, failed = true)
             events.onError("无法初始化本地麦克风：${it.message.orEmpty()}")
             return
         }
         if (record.state != AudioRecord.STATE_INITIALIZED) {
             record.release()
             routeSession.close()
+            VoicePerformanceTrace.finish(traceToken, 0L, failed = true)
             events.onError("无法初始化本地麦克风")
             return
         }
@@ -257,6 +265,7 @@ class LocalAudioVoiceBackend(
             ),
             events = events,
             routeSession = routeSession,
+            traceToken = traceToken,
         )
         val accepted = synchronized(lock) {
             if (startGeneration.get() != generation) {
@@ -269,14 +278,16 @@ class LocalAudioVoiceBackend(
         if (!accepted) {
             record.release()
             routeSession.close()
+            VoicePerformanceTrace.abandon(traceToken)
             return
         }
         session.stopRequested.set(stopRequestedGeneration.get() == generation)
+        if (session.stopRequested.get()) VoicePerformanceTrace.markVoiceRelease(traceToken)
 
         val modelEvents = object : VoiceRecognitionEvents {
             override fun onPartial(text: String) {
                 session.lastPartial = text
-                VoicePerformanceTrace.markFirstPartial()
+                VoicePerformanceTrace.markFirstPartial(session.traceToken)
                 events.onPartial(text)
             }
 
@@ -295,7 +306,7 @@ class LocalAudioVoiceBackend(
             if (record.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
                 throw IllegalStateException("AudioRecord 未进入录音状态")
             }
-            VoicePerformanceTrace.markAudioRecordStart()
+            VoicePerformanceTrace.markAudioRecordStart(session.traceToken)
             val canRun = synchronized(lock) {
                 if (startGeneration.get() != generation || this.session !== session) {
                     false
@@ -335,10 +346,15 @@ class LocalAudioVoiceBackend(
     }
 
     override fun stop() {
-        VoicePerformanceTrace.markVoiceRelease()
+        val current = synchronized(lock) { session }
+        if (current != null) {
+            VoicePerformanceTrace.markVoiceRelease(current.traceToken)
+        } else {
+            runtimeProvider.performanceTraceToken()?.let(VoicePerformanceTrace::markVoiceRelease)
+        }
         val generation = startGeneration.get()
         stopRequestedGeneration.set(generation)
-        val current = synchronized(lock) { session } ?: return
+        if (current == null) return
         current.stopRequested.set(true)
         requestCaptureStop(current)
         if (current.modelReady.get()) startInferenceThread(current)
@@ -355,6 +371,7 @@ class LocalAudioVoiceBackend(
             value
         } ?: return
         current.cancelled.set(true)
+        VoicePerformanceTrace.abandon(current.traceToken)
         requestCaptureStop(current)
         current.ring.clear()
         current.ring.wake()
@@ -375,6 +392,7 @@ class LocalAudioVoiceBackend(
         runCatching { value.record.release() }
         value.routeSession.close()
         value.ring.clear()
+        VoicePerformanceTrace.abandon(value.traceToken)
         synchronized(lock) {
             if (session === value) session = null
         }
@@ -405,7 +423,7 @@ class LocalAudioVoiceBackend(
                 val read = session.record.read(pcm, 0, pcm.size, AudioRecord.READ_BLOCKING)
                 when {
                     read > 0 -> {
-                        VoicePerformanceTrace.markFirstPcm()
+                        VoicePerformanceTrace.markFirstPcm(session.traceToken)
                         val droppedBefore = session.ring.droppedSamples
                         session.ring.offer(pcm, 0, read)
                         if (
@@ -454,11 +472,11 @@ class LocalAudioVoiceBackend(
                 if (pendingCount < pending.size && session.running.get()) continue
                 val chunk = pending.copyOf(pendingCount)
                 pendingCount = 0
-                VoicePerformanceTrace.markFirstDecode()
+                VoicePerformanceTrace.markFirstDecode(session.traceToken)
                 voiceSession.acceptWaveform(pcm16ToFloat(chunk))
             }
             if (pendingCount > 0) {
-                VoicePerformanceTrace.markFirstDecode()
+                VoicePerformanceTrace.markFirstDecode(session.traceToken)
                 voiceSession.acceptWaveform(pcm16ToFloat(pending.copyOf(pendingCount)))
             }
             if (
@@ -467,12 +485,12 @@ class LocalAudioVoiceBackend(
                 session.finished.compareAndSet(false, true)
             ) {
                 val raw = voiceSession.inputFinished().ifBlank { session.lastPartial }
-                VoicePerformanceTrace.markFinalAsr()
+                VoicePerformanceTrace.markFinalAsr(session.traceToken)
                 val punctuated = if (raw.isBlank()) raw else voiceSession.punctuate(raw) ?: raw
                 val final = VoiceCorrectionRepository.apply(punctuated)
-                VoicePerformanceTrace.markPunctuationDone()
+                VoicePerformanceTrace.markPunctuationDone(session.traceToken)
                 session.events.onFinal(final)
-                VoicePerformanceTrace.finish(session.ring.droppedSamples)
+                VoicePerformanceTrace.finish(session.traceToken, session.ring.droppedSamples)
             }
         } catch (error: Throwable) {
             fail(session, "本地语音推理失败：${error.message.orEmpty()}")
@@ -490,7 +508,11 @@ class LocalAudioVoiceBackend(
     private fun fail(session: Session, message: String) {
         if (session.failed.compareAndSet(false, true)) {
             requestCaptureStop(session)
-            VoicePerformanceTrace.finish(session.ring.droppedSamples, failed = true)
+            VoicePerformanceTrace.finish(
+                session.traceToken,
+                session.ring.droppedSamples,
+                failed = true,
+            )
             session.events.onError(message)
             if (!session.modelReady.get() && session.captureThread == null) {
                 cleanupStartingSession(session)
@@ -503,6 +525,7 @@ class LocalAudioVoiceBackend(
         val ring: PcmRingBuffer,
         val events: VoiceRecognitionEvents,
         val routeSession: VoiceAudioRouteManager.Session,
+        val traceToken: VoicePerformanceTrace.Token,
     ) {
         @Volatile
         var voiceSession: StreamingVoiceModelSession? = null

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -155,7 +155,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
     }
 
     override fun onCreateInputView(): View {
-        keyboardView = ImeKeyboardView(this, legacyAdapter)
+        keyboardView = ImeKeyboardViewV2(this, this)
         keyboardView?.setMode(state.keyboardMode)
         keyboardView?.setTheme(state.theme)
         keyboardView?.setAppearance(state.appearance)

--- a/app/src/main/java/llc/slacker/openime/TextEditControlPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/TextEditControlPolicy.kt
@@ -1,0 +1,12 @@
+package llc.slacker.openime
+
+/**
+ * Controls that the legacy text-edit panel renders but cannot implement
+ * reliably across arbitrary target editors. Production keeps them visible as
+ * disabled affordances rather than exposing clickable no-ops.
+ */
+internal object TextEditControlPolicy {
+    private val unavailableLabels = setOf("撤销", "▲", "▼")
+
+    fun isUnavailableLabel(label: String): Boolean = label in unavailableLabels
+}

--- a/app/src/main/java/llc/slacker/openime/VoicePerformanceTrace.kt
+++ b/app/src/main/java/llc/slacker/openime/VoicePerformanceTrace.kt
@@ -6,6 +6,9 @@ import android.util.Log
 /** Session timing only. No transcript, PCM, hotword or editor content is stored. */
 object VoicePerformanceTrace {
     private const val TAG = "OpenImeVoicePerf"
+    private const val MAX_ACTIVE_TRACES = 8
+
+    data class Token internal constructor(val generation: Long)
 
     private data class Trace(
         val startedAt: Long,
@@ -22,39 +25,82 @@ object VoicePerformanceTrace {
     )
 
     private val lock = Any()
-    private var trace: Trace? = null
+    private val traces = LinkedHashMap<Long, Trace>()
+    private var nextGeneration = 0L
+    private var latestGeneration: Long? = null
+    @Volatile
+    private var testClock: (() -> Long)? = null
+    @Volatile
+    private var testLogger: ((String) -> Unit)? = null
 
-    fun begin() = synchronized(lock) {
-        trace = Trace(startedAt = SystemClock.elapsedRealtime())
+    fun begin(): Token = synchronized(lock) {
+        val token = Token(++nextGeneration)
+        traces[token.generation] = Trace(startedAt = now())
+        latestGeneration = token.generation
+        while (traces.size > MAX_ACTIVE_TRACES) {
+            traces.remove(traces.keys.first())
+        }
+        token
     }
 
     /** Debug callback injection is not a real microphone session. */
-    fun abandon() = synchronized(lock) {
-        trace = null
+    fun abandon() {
+        currentToken()?.let(::abandon)
     }
 
-    fun markModelReady() = mark { if (it.modelReadyAt == 0L) it.modelReadyAt = now() }
-    fun markAudioRecordStart() = mark { if (it.audioRecordAt == 0L) it.audioRecordAt = now() }
-    fun markFirstPcm() = mark { if (it.firstPcmAt == 0L) it.firstPcmAt = now() }
-    fun markFirstDecode() = mark { if (it.firstDecodeAt == 0L) it.firstDecodeAt = now() }
-    fun markFirstPartial() = mark { if (it.firstPartialAt == 0L) it.firstPartialAt = now() }
-    fun markVoiceRelease() = mark { if (it.releaseAt == 0L) it.releaseAt = now() }
-    fun markFinalAsr() = mark { if (it.finalAsrAt == 0L) it.finalAsrAt = now() }
-    fun markPunctuationDone() = mark { if (it.punctuationDoneAt == 0L) it.punctuationDoneAt = now() }
+    fun abandon(token: Token) = synchronized(lock) {
+        removeLocked(token.generation)
+    }
+
+    fun markModelReady() = currentToken()?.let(::markModelReady)
+    fun markModelReady(token: Token) = mark(token) { if (it.modelReadyAt == 0L) it.modelReadyAt = now() }
+
+    fun markAudioRecordStart() = currentToken()?.let(::markAudioRecordStart)
+    fun markAudioRecordStart(token: Token) = mark(token) { if (it.audioRecordAt == 0L) it.audioRecordAt = now() }
+
+    fun markFirstPcm() = currentToken()?.let(::markFirstPcm)
+    fun markFirstPcm(token: Token) = mark(token) { if (it.firstPcmAt == 0L) it.firstPcmAt = now() }
+
+    fun markFirstDecode() = currentToken()?.let(::markFirstDecode)
+    fun markFirstDecode(token: Token) = mark(token) { if (it.firstDecodeAt == 0L) it.firstDecodeAt = now() }
+
+    fun markFirstPartial() = currentToken()?.let(::markFirstPartial)
+    fun markFirstPartial(token: Token) = mark(token) { if (it.firstPartialAt == 0L) it.firstPartialAt = now() }
+
+    fun markVoiceRelease() = currentToken()?.let(::markVoiceRelease)
+    fun markVoiceRelease(token: Token) = mark(token) { if (it.releaseAt == 0L) it.releaseAt = now() }
+
+    fun markFinalAsr() = currentToken()?.let(::markFinalAsr)
+    fun markFinalAsr(token: Token) = mark(token) { if (it.finalAsrAt == 0L) it.finalAsrAt = now() }
+
+    fun markPunctuationDone() = currentToken()?.let(::markPunctuationDone)
+    fun markPunctuationDone(token: Token) = mark(token) { if (it.punctuationDoneAt == 0L) it.punctuationDoneAt = now() }
 
     fun markFirstDisplay() {
+        currentToken()?.let(::markFirstDisplay)
+    }
+
+    fun markFirstDisplay(token: Token) {
         synchronized(lock) {
-            val current = trace ?: return
+            val current = traces[token.generation] ?: return
             if (current.firstDisplayAt != 0L) return
             current.firstDisplayAt = now()
-            Log.i(TAG, "firstDisplayMs=${elapsed(current, current.firstDisplayAt)}")
-            if (current.finished) trace = null
+            log("traceGeneration=${token.generation} firstDisplayMs=${elapsed(current, current.firstDisplayAt)}")
+            if (current.finished) removeLocked(token.generation)
         }
     }
 
     fun finish(droppedPcmSamples: Long, failed: Boolean = false) {
+        currentToken()?.let { finish(it, droppedPcmSamples, failed) }
+    }
+
+    fun finish(
+        token: Token,
+        droppedPcmSamples: Long,
+        failed: Boolean = false,
+    ) {
         synchronized(lock) {
-            val current = trace ?: return
+            val current = traces[token.generation] ?: return
             if (current.finished) return
             current.finished = true
             val finishedAt = now()
@@ -68,9 +114,9 @@ object VoicePerformanceTrace {
             } else {
                 -1L
             }
-            Log.i(
-                TAG,
-                "modelReadyMs=${elapsed(current, current.modelReadyAt)} " +
+            log(
+                "traceGeneration=${token.generation} " +
+                    "modelReadyMs=${elapsed(current, current.modelReadyAt)} " +
                     "micStartMs=${elapsed(current, current.audioRecordAt)} " +
                     "firstPcmMs=${elapsed(current, current.firstPcmAt)} " +
                     "firstDecodeMs=${elapsed(current, current.firstDecodeAt)} " +
@@ -78,18 +124,54 @@ object VoicePerformanceTrace {
                     "firstDisplayMs=${elapsed(current, current.firstDisplayAt)} " +
                     "finalizeMs=$finalizeMs punctuationMs=$punctuationMs " +
                     "droppedPcmSamples=$droppedPcmSamples degraded=${droppedPcmSamples > 0L} " +
-                "failed=$failed sessionDurationMs=${finishedAt - current.startedAt}",
+                    "failed=$failed sessionDurationMs=${finishedAt - current.startedAt}",
             )
-            if (current.firstDisplayAt > 0L || failed) trace = null
+            if (current.firstDisplayAt > 0L || failed) removeLocked(token.generation)
         }
     }
 
-    private inline fun mark(block: (Trace) -> Unit) = synchronized(lock) {
-        trace?.let(block)
+    internal fun currentTokenForBackend(): Token? = currentToken()
+
+    internal fun isActiveForTest(token: Token): Boolean = synchronized(lock) {
+        traces.containsKey(token.generation)
+    }
+
+    internal fun activeGenerationsForTest(): List<Long> = synchronized(lock) {
+        traces.keys.toList()
+    }
+
+    internal fun resetForTest(
+        clock: (() -> Long)? = null,
+        logger: ((String) -> Unit)? = null,
+    ) = synchronized(lock) {
+        traces.clear()
+        nextGeneration = 0L
+        latestGeneration = null
+        testClock = clock
+        testLogger = logger
+    }
+
+    private fun currentToken(): Token? = synchronized(lock) {
+        val generation = latestGeneration ?: return@synchronized null
+        if (traces.containsKey(generation)) Token(generation) else null
+    }
+
+    private inline fun mark(token: Token, block: (Trace) -> Unit) = synchronized(lock) {
+        traces[token.generation]?.let(block)
+    }
+
+    private fun removeLocked(generation: Long) {
+        traces.remove(generation)
+        if (latestGeneration == generation) latestGeneration = traces.keys.lastOrNull()
     }
 
     private fun elapsed(current: Trace, timestamp: Long): Long =
         if (timestamp == 0L) -1L else timestamp - current.startedAt
 
-    private fun now(): Long = SystemClock.elapsedRealtime()
+    private fun now(): Long = testClock?.invoke() ?: SystemClock.elapsedRealtime()
+
+    private fun log(message: String) {
+        val logger = testLogger
+        if (logger != null) logger(message) else Log.i(TAG, message)
+    }
 }

--- a/app/src/test/java/llc/slacker/openime/ClipboardRetentionPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ClipboardRetentionPolicyTest.kt
@@ -1,0 +1,50 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardRetentionPolicyTest {
+
+    private val now = 1_000_000_000L
+
+    @Test
+    fun unpinnedEntriesExpireAfterTwentyFourHours() {
+        val fresh = ClipboardEntry("fresh", now - ClipboardRetentionPolicy.UNPINNED_TTL_MS, false)
+        val expired = ClipboardEntry("expired", now - ClipboardRetentionPolicy.UNPINNED_TTL_MS - 1L, false)
+
+        assertTrue(ClipboardRetentionPolicy.retain(fresh, now))
+        assertFalse(ClipboardRetentionPolicy.retain(expired, now))
+    }
+
+    @Test
+    fun pinnedEntriesIgnoreAgeAndLegacyMissingTimestamp() {
+        val oldPinned = ClipboardEntry("pinned", 1L, true)
+        val legacyPinned = ClipboardEntry("legacy", 0L, true)
+
+        assertTrue(ClipboardRetentionPolicy.retain(oldPinned, now))
+        assertTrue(ClipboardRetentionPolicy.retain(legacyPinned, now))
+    }
+
+    @Test
+    fun legacyUnpinnedEntryWithoutTimestampIsPrunedPredictably() {
+        assertFalse(ClipboardRetentionPolicy.retain(ClipboardEntry("legacy", 0L, false), now))
+    }
+
+    @Test
+    fun clockRollbackDoesNotDeleteARecentlyWrittenEntry() {
+        assertTrue(ClipboardRetentionPolicy.retain(ClipboardEntry("future", now + 1_000L, false), now))
+    }
+
+    @Test
+    fun prunePreservesOrderOfRetainedItems() {
+        val entries = listOf(
+            ClipboardEntry("fresh", now - 1_000L, false),
+            ClipboardEntry("expired", now - ClipboardRetentionPolicy.UNPINNED_TTL_MS - 1L, false),
+            ClipboardEntry("pinned", 1L, true),
+        )
+
+        assertEquals(listOf("fresh", "pinned"), ClipboardRetentionPolicy.prune(entries, now).map { it.text })
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/ImeBottomInsetPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ImeBottomInsetPolicyTest.kt
@@ -1,0 +1,43 @@
+package llc.slacker.openime
+
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImeBottomInsetPolicyTest {
+
+    @Test
+    fun zeroInsetPreservesExistingHeight() {
+        assertEquals(
+            296,
+            ImeBottomInsetPolicy.measuredHeight(296, 0, View.MeasureSpec.UNSPECIFIED, 0),
+        )
+    }
+
+    @Test
+    fun navigationInsetAddsSafeAreaWithoutShrinkingKeyboardBody() {
+        assertEquals(
+            320,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.UNSPECIFIED, 0),
+        )
+    }
+
+    @Test
+    fun parentConstraintStillCapsTheIme() {
+        assertEquals(
+            304,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.AT_MOST, 304),
+        )
+        assertEquals(
+            300,
+            ImeBottomInsetPolicy.measuredHeight(296, 24, View.MeasureSpec.EXACTLY, 300),
+        )
+    }
+
+    @Test
+    fun reportedInsetIsBoundedAndNeverNegative() {
+        assertEquals(0, ImeBottomInsetPolicy.clampInset(-5, 32))
+        assertEquals(18, ImeBottomInsetPolicy.clampInset(18, 32))
+        assertEquals(32, ImeBottomInsetPolicy.clampInset(70, 32))
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/TextEditControlPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/TextEditControlPolicyTest.kt
@@ -1,0 +1,18 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TextEditControlPolicyTest {
+
+    @Test
+    fun onlyKnownNoOpControlsAreUnavailable() {
+        listOf("撤销", "▲", "▼").forEach { label ->
+            assertTrue(label, TextEditControlPolicy.isUnavailableLabel(label))
+        }
+        listOf("全选", "复制", "剪切", "粘贴", "◀", "▶").forEach { label ->
+            assertFalse(label, TextEditControlPolicy.isUnavailableLabel(label))
+        }
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/VoicePerformanceTraceGenerationTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoicePerformanceTraceGenerationTest.kt
@@ -1,0 +1,102 @@
+package llc.slacker.openime
+
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoicePerformanceTraceGenerationTest {
+
+    @After
+    fun tearDown() {
+        VoicePerformanceTrace.resetForTest()
+    }
+
+    @Test
+    fun staleFinishCannotEndNewerTrace() {
+        val clock = AtomicLong(1_000L)
+        val logs = mutableListOf<String>()
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = { logs.add(it) },
+        )
+
+        val sessionA = VoicePerformanceTrace.begin()
+        val sessionB = VoicePerformanceTrace.begin()
+        VoicePerformanceTrace.markFirstPartial(sessionA)
+        VoicePerformanceTrace.markFirstPartial(sessionB)
+
+        VoicePerformanceTrace.finish(sessionA, droppedPcmSamples = 7L, failed = true)
+
+        assertFalse(VoicePerformanceTrace.isActiveForTest(sessionA))
+        assertTrue(VoicePerformanceTrace.isActiveForTest(sessionB))
+
+        // A's late callbacks are stale and must not mutate/remove B.
+        VoicePerformanceTrace.markFirstDecode(sessionA)
+        VoicePerformanceTrace.finish(sessionA, droppedPcmSamples = 999L, failed = true)
+        assertTrue(VoicePerformanceTrace.isActiveForTest(sessionB))
+
+        VoicePerformanceTrace.finish(sessionB, droppedPcmSamples = 0L, failed = true)
+        assertFalse(VoicePerformanceTrace.isActiveForTest(sessionB))
+        assertTrue(logs.any { it.contains("traceGeneration=${sessionA.generation}") })
+        assertTrue(logs.any { it.contains("traceGeneration=${sessionB.generation}") })
+    }
+
+    @Test
+    fun interleavedThreadsKeepTheirOwnGenerations() {
+        val clock = AtomicLong(2_000L)
+        val logs = Collections.synchronizedList(mutableListOf<String>())
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = { logs.add(it) },
+        )
+
+        val sessionA = VoicePerformanceTrace.begin()
+        val sessionB = VoicePerformanceTrace.begin()
+
+        val threadA = Thread {
+            repeat(100) {
+                VoicePerformanceTrace.markFirstPcm(sessionA)
+                VoicePerformanceTrace.markFirstDecode(sessionA)
+            }
+            VoicePerformanceTrace.finish(sessionA, droppedPcmSamples = 11L, failed = true)
+        }
+        val threadB = Thread {
+            repeat(100) {
+                VoicePerformanceTrace.markFirstPcm(sessionB)
+                VoicePerformanceTrace.markFirstPartial(sessionB)
+            }
+            VoicePerformanceTrace.finish(sessionB, droppedPcmSamples = 0L, failed = true)
+        }
+
+        threadA.start()
+        threadB.start()
+        threadA.join()
+        threadB.join()
+
+        assertTrue(VoicePerformanceTrace.activeGenerationsForTest().isEmpty())
+        val joined = logs.joinToString("\n")
+        assertTrue(joined.contains("traceGeneration=${sessionA.generation}"))
+        assertTrue(joined.contains("droppedPcmSamples=11"))
+        assertTrue(joined.contains("traceGeneration=${sessionB.generation}"))
+        assertTrue(joined.contains("droppedPcmSamples=0"))
+    }
+
+    @Test
+    fun abandoningOldSessionLeavesNewSessionActive() {
+        val clock = AtomicLong(3_000L)
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = {},
+        )
+
+        val sessionA = VoicePerformanceTrace.begin()
+        val sessionB = VoicePerformanceTrace.begin()
+        VoicePerformanceTrace.abandon(sessionA)
+
+        assertFalse(VoicePerformanceTrace.isActiveForTest(sessionA))
+        assertTrue(VoicePerformanceTrace.isActiveForTest(sessionB))
+    }
+}


### PR DESCRIPTION
## Summary
- apply navigation-bar bottom insets through the production `ImeKeyboardViewV2` safe area on API 29 and API 30+
- keep the existing keyboard body geometry intact while adding only bounded unconsumed bottom inset
- disable unsupported text-edit `撤销` / `▲` / `▼` controls instead of exposing silent no-op buttons
- expire unpinned persisted clipboard history after 24 hours while retaining pinned entries
- add explicit “清除未固定” and “清空全部” clipboard actions without clearing the system clipboard or immediately re-capturing the unchanged clip
- isolate `VoicePerformanceTrace` by session generation so stale voice workers cannot mark or finish a newer session
- bind trace tokens to `LocalAudioVoiceBackend.Session` and add deterministic interleaving tests
- retain the existing unit/policy/instrumentation coverage for the UI and clipboard changes

## Validation
- the constituent #34, #20, #40, and isolated #24 changes each passed Android CI on their previous branches
- this consolidated single-commit branch is based on the current `main`; the final strict `Build and verify` check is required before merge

Closes #34
Closes #20
Closes #40
Closes #24