### PR TITLE
Isolate voice performance traces by session generation

### DIFF
--- a/app/src/main/java/llc/slacker/openime/LocalAudioVoiceBackend.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalAudioVoiceBackend.kt
@@ -141,6 +141,10 @@ interface StreamingVoiceRuntimeProvider {
     fun isExpectedAvailable(): Boolean
 
     fun awaitRuntime(): StreamingEmbeddedVoiceModelRuntime?
+
+    /** Trace token created by the service before this voice gesture starts. */
+    fun performanceTraceToken(): VoicePerformanceTrace.Token? =
+        VoicePerformanceTrace.currentTokenForBackend()
 }
 
 private class FixedStreamingVoiceRuntimeProvider(
@@ -193,10 +197,11 @@ class LocalAudioVoiceBackend(
             return
         }
 
+        val traceToken = runtimeProvider.performanceTraceToken() ?: VoicePerformanceTrace.begin()
         val generation = startGeneration.incrementAndGet()
         stopRequestedGeneration.set(-1L)
         startExecutor.execute {
-            initializeSession(generation, languageTag, events)
+            initializeSession(generation, languageTag, events, traceToken)
         }
     }
 
@@ -205,14 +210,15 @@ class LocalAudioVoiceBackend(
         generation: Long,
         languageTag: String,
         events: VoiceRecognitionEvents,
+        traceToken: VoicePerformanceTrace.Token,
     ) {
-
         val minBufferBytes = AudioRecord.getMinBufferSize(
             LocalVoiceAudioSpec.SAMPLE_RATE,
             LocalVoiceAudioSpec.CHANNEL_MASK,
             LocalVoiceAudioSpec.ENCODING,
         )
         if (minBufferBytes <= 0) {
+            VoicePerformanceTrace.finish(traceToken, 0L, failed = true)
             events.onError("设备不支持 16kHz 麦克风采集")
             return
         }
@@ -240,12 +246,14 @@ class LocalAudioVoiceBackend(
                 .build()
         }.getOrElse {
             routeSession.close()
+            VoicePerformanceTrace.finish(traceToken, 0L, failed = true)
             events.onError("无法初始化本地麦克风：${it.message.orEmpty()}")
             return
         }
         if (record.state != AudioRecord.STATE_INITIALIZED) {
             record.release()
             routeSession.close()
+            VoicePerformanceTrace.finish(traceToken, 0L, failed = true)
             events.onError("无法初始化本地麦克风")
             return
         }
@@ -257,6 +265,7 @@ class LocalAudioVoiceBackend(
             ),
             events = events,
             routeSession = routeSession,
+            traceToken = traceToken,
         )
         val accepted = synchronized(lock) {
             if (startGeneration.get() != generation) {
@@ -269,14 +278,16 @@ class LocalAudioVoiceBackend(
         if (!accepted) {
             record.release()
             routeSession.close()
+            VoicePerformanceTrace.abandon(traceToken)
             return
         }
         session.stopRequested.set(stopRequestedGeneration.get() == generation)
+        if (session.stopRequested.get()) VoicePerformanceTrace.markVoiceRelease(traceToken)
 
         val modelEvents = object : VoiceRecognitionEvents {
             override fun onPartial(text: String) {
                 session.lastPartial = text
-                VoicePerformanceTrace.markFirstPartial()
+                VoicePerformanceTrace.markFirstPartial(session.traceToken)
                 events.onPartial(text)
             }
 
@@ -295,7 +306,7 @@ class LocalAudioVoiceBackend(
             if (record.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
                 throw IllegalStateException("AudioRecord 未进入录音状态")
             }
-            VoicePerformanceTrace.markAudioRecordStart()
+            VoicePerformanceTrace.markAudioRecordStart(session.traceToken)
             val canRun = synchronized(lock) {
                 if (startGeneration.get() != generation || this.session !== session) {
                     false
@@ -335,10 +346,15 @@ class LocalAudioVoiceBackend(
     }
 
     override fun stop() {
-        VoicePerformanceTrace.markVoiceRelease()
+        val current = synchronized(lock) { session }
+        if (current != null) {
+            VoicePerformanceTrace.markVoiceRelease(current.traceToken)
+        } else {
+            runtimeProvider.performanceTraceToken()?.let(VoicePerformanceTrace::markVoiceRelease)
+        }
         val generation = startGeneration.get()
         stopRequestedGeneration.set(generation)
-        val current = synchronized(lock) { session } ?: return
+        if (current == null) return
         current.stopRequested.set(true)
         requestCaptureStop(current)
         if (current.modelReady.get()) startInferenceThread(current)
@@ -355,6 +371,7 @@ class LocalAudioVoiceBackend(
             value
         } ?: return
         current.cancelled.set(true)
+        VoicePerformanceTrace.abandon(current.traceToken)
         requestCaptureStop(current)
         current.ring.clear()
         current.ring.wake()
@@ -375,6 +392,7 @@ class LocalAudioVoiceBackend(
         runCatching { value.record.release() }
         value.routeSession.close()
         value.ring.clear()
+        VoicePerformanceTrace.abandon(value.traceToken)
         synchronized(lock) {
             if (session === value) session = null
         }
@@ -405,7 +423,7 @@ class LocalAudioVoiceBackend(
                 val read = session.record.read(pcm, 0, pcm.size, AudioRecord.READ_BLOCKING)
                 when {
                     read > 0 -> {
-                        VoicePerformanceTrace.markFirstPcm()
+                        VoicePerformanceTrace.markFirstPcm(session.traceToken)
                         val droppedBefore = session.ring.droppedSamples
                         session.ring.offer(pcm, 0, read)
                         if (
@@ -454,11 +472,11 @@ class LocalAudioVoiceBackend(
                 if (pendingCount < pending.size && session.running.get()) continue
                 val chunk = pending.copyOf(pendingCount)
                 pendingCount = 0
-                VoicePerformanceTrace.markFirstDecode()
+                VoicePerformanceTrace.markFirstDecode(session.traceToken)
                 voiceSession.acceptWaveform(pcm16ToFloat(chunk))
             }
             if (pendingCount > 0) {
-                VoicePerformanceTrace.markFirstDecode()
+                VoicePerformanceTrace.markFirstDecode(session.traceToken)
                 voiceSession.acceptWaveform(pcm16ToFloat(pending.copyOf(pendingCount)))
             }
             if (
@@ -467,12 +485,12 @@ class LocalAudioVoiceBackend(
                 session.finished.compareAndSet(false, true)
             ) {
                 val raw = voiceSession.inputFinished().ifBlank { session.lastPartial }
-                VoicePerformanceTrace.markFinalAsr()
+                VoicePerformanceTrace.markFinalAsr(session.traceToken)
                 val punctuated = if (raw.isBlank()) raw else voiceSession.punctuate(raw) ?: raw
                 val final = VoiceCorrectionRepository.apply(punctuated)
-                VoicePerformanceTrace.markPunctuationDone()
+                VoicePerformanceTrace.markPunctuationDone(session.traceToken)
                 session.events.onFinal(final)
-                VoicePerformanceTrace.finish(session.ring.droppedSamples)
+                VoicePerformanceTrace.finish(session.traceToken, session.ring.droppedSamples)
             }
         } catch (error: Throwable) {
             fail(session, "本地语音推理失败：${error.message.orEmpty()}")
@@ -490,7 +508,11 @@ class LocalAudioVoiceBackend(
     private fun fail(session: Session, message: String) {
         if (session.failed.compareAndSet(false, true)) {
             requestCaptureStop(session)
-            VoicePerformanceTrace.finish(session.ring.droppedSamples, failed = true)
+            VoicePerformanceTrace.finish(
+                session.traceToken,
+                session.ring.droppedSamples,
+                failed = true,
+            )
             session.events.onError(message)
             if (!session.modelReady.get() && session.captureThread == null) {
                 cleanupStartingSession(session)
@@ -503,6 +525,7 @@ class LocalAudioVoiceBackend(
         val ring: PcmRingBuffer,
         val events: VoiceRecognitionEvents,
         val routeSession: VoiceAudioRouteManager.Session,
+        val traceToken: VoicePerformanceTrace.Token,
     ) {
         @Volatile
         var voiceSession: StreamingVoiceModelSession? = null

--- a/app/src/main/java/llc/slacker/openime/VoicePerformanceTrace.kt
+++ b/app/src/main/java/llc/slacker/openime/VoicePerformanceTrace.kt
@@ -6,6 +6,9 @@ import android.util.Log
 /** Session timing only. No transcript, PCM, hotword or editor content is stored. */
 object VoicePerformanceTrace {
     private const val TAG = "OpenImeVoicePerf"
+    private const val MAX_ACTIVE_TRACES = 8
+
+    data class Token internal constructor(val generation: Long)
 
     private data class Trace(
         val startedAt: Long,
@@ -22,39 +25,82 @@ object VoicePerformanceTrace {
     )
 
     private val lock = Any()
-    private var trace: Trace? = null
+    private val traces = LinkedHashMap<Long, Trace>()
+    private var nextGeneration = 0L
+    private var latestGeneration: Long? = null
+    @Volatile
+    private var testClock: (() -> Long)? = null
+    @Volatile
+    private var testLogger: ((String) -> Unit)? = null
 
-    fun begin() = synchronized(lock) {
-        trace = Trace(startedAt = SystemClock.elapsedRealtime())
+    fun begin(): Token = synchronized(lock) {
+        val token = Token(++nextGeneration)
+        traces[token.generation] = Trace(startedAt = now())
+        latestGeneration = token.generation
+        while (traces.size > MAX_ACTIVE_TRACES) {
+            traces.remove(traces.keys.first())
+        }
+        token
     }
 
     /** Debug callback injection is not a real microphone session. */
-    fun abandon() = synchronized(lock) {
-        trace = null
+    fun abandon() {
+        currentToken()?.let(::abandon)
     }
 
-    fun markModelReady() = mark { if (it.modelReadyAt == 0L) it.modelReadyAt = now() }
-    fun markAudioRecordStart() = mark { if (it.audioRecordAt == 0L) it.audioRecordAt = now() }
-    fun markFirstPcm() = mark { if (it.firstPcmAt == 0L) it.firstPcmAt = now() }
-    fun markFirstDecode() = mark { if (it.firstDecodeAt == 0L) it.firstDecodeAt = now() }
-    fun markFirstPartial() = mark { if (it.firstPartialAt == 0L) it.firstPartialAt = now() }
-    fun markVoiceRelease() = mark { if (it.releaseAt == 0L) it.releaseAt = now() }
-    fun markFinalAsr() = mark { if (it.finalAsrAt == 0L) it.finalAsrAt = now() }
-    fun markPunctuationDone() = mark { if (it.punctuationDoneAt == 0L) it.punctuationDoneAt = now() }
+    fun abandon(token: Token) = synchronized(lock) {
+        removeLocked(token.generation)
+    }
+
+    fun markModelReady() = currentToken()?.let(::markModelReady)
+    fun markModelReady(token: Token) = mark(token) { if (it.modelReadyAt == 0L) it.modelReadyAt = now() }
+
+    fun markAudioRecordStart() = currentToken()?.let(::markAudioRecordStart)
+    fun markAudioRecordStart(token: Token) = mark(token) { if (it.audioRecordAt == 0L) it.audioRecordAt = now() }
+
+    fun markFirstPcm() = currentToken()?.let(::markFirstPcm)
+    fun markFirstPcm(token: Token) = mark(token) { if (it.firstPcmAt == 0L) it.firstPcmAt = now() }
+
+    fun markFirstDecode() = currentToken()?.let(::markFirstDecode)
+    fun markFirstDecode(token: Token) = mark(token) { if (it.firstDecodeAt == 0L) it.firstDecodeAt = now() }
+
+    fun markFirstPartial() = currentToken()?.let(::markFirstPartial)
+    fun markFirstPartial(token: Token) = mark(token) { if (it.firstPartialAt == 0L) it.firstPartialAt = now() }
+
+    fun markVoiceRelease() = currentToken()?.let(::markVoiceRelease)
+    fun markVoiceRelease(token: Token) = mark(token) { if (it.releaseAt == 0L) it.releaseAt = now() }
+
+    fun markFinalAsr() = currentToken()?.let(::markFinalAsr)
+    fun markFinalAsr(token: Token) = mark(token) { if (it.finalAsrAt == 0L) it.finalAsrAt = now() }
+
+    fun markPunctuationDone() = currentToken()?.let(::markPunctuationDone)
+    fun markPunctuationDone(token: Token) = mark(token) { if (it.punctuationDoneAt == 0L) it.punctuationDoneAt = now() }
 
     fun markFirstDisplay() {
+        currentToken()?.let(::markFirstDisplay)
+    }
+
+    fun markFirstDisplay(token: Token) {
         synchronized(lock) {
-            val current = trace ?: return
+            val current = traces[token.generation] ?: return
             if (current.firstDisplayAt != 0L) return
             current.firstDisplayAt = now()
-            Log.i(TAG, "firstDisplayMs=${elapsed(current, current.firstDisplayAt)}")
-            if (current.finished) trace = null
+            log("traceGeneration=${token.generation} firstDisplayMs=${elapsed(current, current.firstDisplayAt)}")
+            if (current.finished) removeLocked(token.generation)
         }
     }
 
     fun finish(droppedPcmSamples: Long, failed: Boolean = false) {
+        currentToken()?.let { finish(it, droppedPcmSamples, failed) }
+    }
+
+    fun finish(
+        token: Token,
+        droppedPcmSamples: Long,
+        failed: Boolean = false,
+    ) {
         synchronized(lock) {
-            val current = trace ?: return
+            val current = traces[token.generation] ?: return
             if (current.finished) return
             current.finished = true
             val finishedAt = now()
@@ -68,9 +114,9 @@ object VoicePerformanceTrace {
             } else {
                 -1L
             }
-            Log.i(
-                TAG,
-                "modelReadyMs=${elapsed(current, current.modelReadyAt)} " +
+            log(
+                "traceGeneration=${token.generation} " +
+                    "modelReadyMs=${elapsed(current, current.modelReadyAt)} " +
                     "micStartMs=${elapsed(current, current.audioRecordAt)} " +
                     "firstPcmMs=${elapsed(current, current.firstPcmAt)} " +
                     "firstDecodeMs=${elapsed(current, current.firstDecodeAt)} " +
@@ -78,18 +124,54 @@ object VoicePerformanceTrace {
                     "firstDisplayMs=${elapsed(current, current.firstDisplayAt)} " +
                     "finalizeMs=$finalizeMs punctuationMs=$punctuationMs " +
                     "droppedPcmSamples=$droppedPcmSamples degraded=${droppedPcmSamples > 0L} " +
-                "failed=$failed sessionDurationMs=${finishedAt - current.startedAt}",
+                    "failed=$failed sessionDurationMs=${finishedAt - current.startedAt}",
             )
-            if (current.firstDisplayAt > 0L || failed) trace = null
+            if (current.firstDisplayAt > 0L || failed) removeLocked(token.generation)
         }
     }
 
-    private inline fun mark(block: (Trace) -> Unit) = synchronized(lock) {
-        trace?.let(block)
+    internal fun currentTokenForBackend(): Token? = currentToken()
+
+    internal fun isActiveForTest(token: Token): Boolean = synchronized(lock) {
+        traces.containsKey(token.generation)
+    }
+
+    internal fun activeGenerationsForTest(): List<Long> = synchronized(lock) {
+        traces.keys.toList()
+    }
+
+    internal fun resetForTest(
+        clock: (() -> Long)? = null,
+        logger: ((String) -> Unit)? = null,
+    ) = synchronized(lock) {
+        traces.clear()
+        nextGeneration = 0L
+        latestGeneration = null
+        testClock = clock
+        testLogger = logger
+    }
+
+    private fun currentToken(): Token? = synchronized(lock) {
+        val generation = latestGeneration ?: return@synchronized null
+        if (traces.containsKey(generation)) Token(generation) else null
+    }
+
+    private inline fun mark(token: Token, block: (Trace) -> Unit) = synchronized(lock) {
+        traces[token.generation]?.let(block)
+    }
+
+    private fun removeLocked(generation: Long) {
+        traces.remove(generation)
+        if (latestGeneration == generation) latestGeneration = traces.keys.lastOrNull()
     }
 
     private fun elapsed(current: Trace, timestamp: Long): Long =
         if (timestamp == 0L) -1L else timestamp - current.startedAt
 
-    private fun now(): Long = SystemClock.elapsedRealtime()
+    private fun now(): Long = testClock?.invoke() ?: SystemClock.elapsedRealtime()
+
+    private fun log(message: String) {
+        val logger = testLogger
+        if (logger != null) logger(message) else Log.i(TAG, message)
+    }
 }

--- a/app/src/test/java/llc/slacker/openime/VoicePerformanceTraceGenerationTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoicePerformanceTraceGenerationTest.kt
@@ -1,0 +1,102 @@
+package llc.slacker.openime
+
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoicePerformanceTraceGenerationTest {
+
+    @After
+    fun tearDown() {
+        VoicePerformanceTrace.resetForTest()
+    }
+
+    @Test
+    fun staleFinishCannotEndNewerTrace() {
+        val clock = AtomicLong(1_000L)
+        val logs = mutableListOf<String>()
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = { logs.add(it) },
+        )
+
+        val sessionA = VoicePerformanceTrace.begin()
+        val sessionB = VoicePerformanceTrace.begin()
+        VoicePerformanceTrace.markFirstPartial(sessionA)
+        VoicePerformanceTrace.markFirstPartial(sessionB)
+
+        VoicePerformanceTrace.finish(sessionA, droppedPcmSamples = 7L, failed = true)
+
+        assertFalse(VoicePerformanceTrace.isActiveForTest(sessionA))
+        assertTrue(VoicePerformanceTrace.isActiveForTest(sessionB))
+
+        // A's late callbacks are stale and must not mutate/remove B.
+        VoicePerformanceTrace.markFirstDecode(sessionA)
+        VoicePerformanceTrace.finish(sessionA, droppedPcmSamples = 999L, failed = true)
+        assertTrue(VoicePerformanceTrace.isActiveForTest(sessionB))
+
+        VoicePerformanceTrace.finish(sessionB, droppedPcmSamples = 0L, failed = true)
+        assertFalse(VoicePerformanceTrace.isActiveForTest(sessionB))
+        assertTrue(logs.any { it.contains("traceGeneration=${sessionA.generation}") })
+        assertTrue(logs.any { it.contains("traceGeneration=${sessionB.generation}") })
+    }
+
+    @Test
+    fun interleavedThreadsKeepTheirOwnGenerations() {
+        val clock = AtomicLong(2_000L)
+        val logs = Collections.synchronizedList(mutableListOf<String>())
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = { logs.add(it) },
+        )
+
+        val sessionA = VoicePerformanceTrace.begin()
+        val sessionB = VoicePerformanceTrace.begin()
+
+        val threadA = Thread {
+            repeat(100) {
+                VoicePerformanceTrace.markFirstPcm(sessionA)
+                VoicePerformanceTrace.markFirstDecode(sessionA)
+            }
+            VoicePerformanceTrace.finish(sessionA, droppedPcmSamples = 11L, failed = true)
+        }
+        val threadB = Thread {
+            repeat(100) {
+                VoicePerformanceTrace.markFirstPcm(sessionB)
+                VoicePerformanceTrace.markFirstPartial(sessionB)
+            }
+            VoicePerformanceTrace.finish(sessionB, droppedPcmSamples = 0L, failed = true)
+        }
+
+        threadA.start()
+        threadB.start()
+        threadA.join()
+        threadB.join()
+
+        assertTrue(VoicePerformanceTrace.activeGenerationsForTest().isEmpty())
+        val joined = logs.joinToString("\n")
+        assertTrue(joined.contains("traceGeneration=${sessionA.generation}"))
+        assertTrue(joined.contains("droppedPcmSamples=11"))
+        assertTrue(joined.contains("traceGeneration=${sessionB.generation}"))
+        assertTrue(joined.contains("droppedPcmSamples=0"))
+    }
+
+    @Test
+    fun abandoningOldSessionLeavesNewSessionActive() {
+        val clock = AtomicLong(3_000L)
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = {},
+        )
+
+        val sessionA = VoicePerformanceTrace.begin()
+        val sessionB = VoicePerformanceTrace.begin()
+        VoicePerformanceTrace.abandon(sessionA)
+
+        assertFalse(VoicePerformanceTrace.isActiveForTest(sessionA))
+        assertTrue(VoicePerformanceTrace.isActiveForTest(sessionB))
+    }
+}


### PR DESCRIPTION
## Summary
- replace the singleton's overwrite-only trace slot with generation-scoped active traces
- make `begin()` return a session token and keep a small bounded set of active traces so interleaved sessions cannot overwrite each other
- bind each `LocalAudioVoiceBackend.Session` to its own trace token and use that token for PCM/decode/partial/release/final/punctuation/failure marks
- abandon cancelled/stale startup sessions explicitly so late worker callbacks become harmless no-ops
- keep legacy no-arg display/lifecycle calls for already-current UI paths while the backend worker paths use explicit tokens
- add deterministic host test clock/logger hooks and concurrency tests proving stale finish/mark/abandon cannot end a newer trace

## Dependency
- stacked on #64 / issue #17 so the trace changes are tested against the current voice-runtime branch

## Validation
- Android CI pending

Closes #24