### PR TITLE
Add Android 10/12 compatibility CI and OEM-safe UI synchronization

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,3 +70,74 @@ jobs:
           name: openIME-debug
           path: app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+
+  compatibility:
+    name: Compatibility API ${{ matrix.api-level }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [29, 31]
+
+    steps:
+      - name: Checkout source and LFS files
+        uses: actions/checkout@v7
+        with:
+          lfs: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Install Android build components
+        shell: bash
+        run: |
+          sdkmanager "platforms;android-36" \
+            "build-tools;35.0.0" \
+            "ndk;27.0.12077973" \
+            "cmake;3.22.1"
+
+      - name: Verify LFS objects
+        shell: bash
+        run: |
+          git lfs checkout
+          if grep -RIl --exclude-dir=.git "version https://git-lfs.github.com/spec/v1" app/libs app/src/main/assets/models; then
+            echo "A Git LFS pointer was left unresolved" >&2
+            exit 1
+          fi
+
+      - name: Fetch pinned librime dependencies
+        shell: bash
+        run: bash scripts/fetch_rime_deps.sh
+
+      - name: Ensure Gradle wrapper is executable
+        shell: bash
+        run: chmod +x gradlew
+
+      - name: Run compatibility instrumentation
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          target: default
+          profile: pixel_2
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: ./gradlew :app:connectedDebugAndroidTest --no-daemon --console=plain
+
+      - name: Upload compatibility test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: compatibility-api-${{ matrix.api-level }}
+          path: |
+            app/build/reports/androidTests/connected
+            app/build/outputs/androidTest-results/connected
+          if-no-files-found: warn

--- a/app/src/androidTest/java/llc/slacker/openime/CompatibilityApiInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/CompatibilityApiInstrumentedTest.kt
@@ -1,0 +1,92 @@
+package llc.slacker.openime
+
+import android.Manifest
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.PersistableBundle
+import android.view.View
+import android.view.inputmethod.BaseInputConnection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Core compatibility smoke coverage against current production APIs on API 29 and 31. */
+@RunWith(AndroidJUnit4::class)
+class CompatibilityApiInstrumentedTest {
+
+    @Test
+    fun pPlusBackspaceUsesCodePointDeletionForUnicodeSafety() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val connection = RecordingInputConnection(View(context))
+        val gateway = InputConnectionGateway(context, { connection })
+
+        gateway.deleteBackwards()
+
+        assertTrue("API 29+ must use code-point deletion", connection.codePointDeleteCalled)
+        assertFalse("API 29+ must not fall back to UTF-16 unit deletion", connection.utf16DeleteCalled)
+    }
+
+    @Test
+    fun sensitiveClipboardIsNeverCapturedIntoPersistentHistory() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        ClipboardHistoryRepository.clearAll(context)
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("secret", "compat-secret")
+        clip.description.extras = PersistableBundle().apply {
+            putBoolean(ClipboardSensitivityPolicy.SENSITIVE_KEY, true)
+        }
+        clipboard.setPrimaryClip(clip)
+
+        assertFalse(ClipboardHistoryRepository.capturePrimary(context))
+        assertTrue(ClipboardHistoryRepository.load(context).isEmpty())
+    }
+
+    @Test
+    fun bundledCandidateEngineWorksOnCompatibilityApi() {
+        assertTrue(CandidateEngine().getCandidates("nihao").contains("你好"))
+    }
+
+    @Test
+    fun freshCompatibilityDeviceReportsVoicePermissionFailureWithoutStartingCapture() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        assumeTrue(
+            "compatibility image has RECORD_AUDIO pre-granted; permission-path check skipped",
+            context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED,
+        )
+        var error = ""
+        LocalAudioVoiceBackend(context, runtime = null).start(
+            "zh-CN",
+            object : VoiceRecognitionEvents {
+                override fun onPartial(text: String) = Unit
+                override fun onFinal(text: String) = Unit
+                override fun onRms(rms: Float) = Unit
+                override fun onError(message: String) {
+                    error = message
+                }
+                override fun onReady() = Unit
+            },
+        )
+        assertTrue(error.contains("麦克风权限"))
+    }
+
+    private class RecordingInputConnection(view: View) : BaseInputConnection(view, false) {
+        var codePointDeleteCalled = false
+        var utf16DeleteCalled = false
+
+        override fun deleteSurroundingTextInCodePoints(beforeLength: Int, afterLength: Int): Boolean {
+            codePointDeleteCalled = true
+            return true
+        }
+
+        override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+            utf16DeleteCalled = true
+            return true
+        }
+    }
+}

--- a/app/src/androidTest/java/llc/slacker/openime/DebugKeyboardActivityTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/DebugKeyboardActivityTest.kt
@@ -5,66 +5,86 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Rule
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.Assert.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class DebugKeyboardActivityTest {
 
-    @get:Rule
-    val rule = ActivityScenarioRule(DebugKeyboardActivity::class.java)
+    private lateinit var harness: DirectActivityHarness<DebugKeyboardActivity>
+
+    @Before
+    fun launch() {
+        harness = DirectActivityHarness(DebugKeyboardActivity::class.java)
+        harness.launch()
+    }
+
+    @After
+    fun close() {
+        harness.close()
+    }
 
     @Test
     fun activityRendersKeyboard() {
-        rule.scenario.onActivity { activity ->
-            assertTrue(activity.window.decorView.isShown)
-            assertTrue(activity.findViewById<View>(android.R.id.content)?.isShown == true)
+        val shown = harness.awaitMain { activity ->
+            activity.window.decorView.takeIf { it.isShown }
         }
+        assertTrue(shown.isShown)
+        assertTrue(
+            harness.awaitMain { activity ->
+                activity.findViewById<View>(android.R.id.content)?.takeIf { it.isShown }
+            }.isShown,
+        )
     }
 
     @Test
     fun keyboardContainsManyInteractiveNodes() {
-        rule.scenario.onActivity { activity ->
+        val counts = harness.awaitMain { activity ->
             var clickableViews = 0
             var textViews = 0
             fun walk(view: View) {
                 if (view.isClickable && view !is ImeKeyboardView) clickableViews++
-                if (view is android.widget.TextView) textViews++
+                if (view is TextView) textViews++
                 if (view is ViewGroup) {
-                    for (i in 0 until view.childCount) walk(view.getChildAt(i))
+                    for (index in 0 until view.childCount) walk(view.getChildAt(index))
                 }
             }
-            activity.findViewById<ViewGroup>(android.R.id.content)?.let(::walk)
-            assertTrue("expected keyboard controls, got $clickableViews", clickableViews >= 30)
-            assertTrue("expected text nodes, got $textViews", textViews >= 3)
+            val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
+            walk(root)
+            if (clickableViews < 30 || textViews < 3) null else clickableViews to textViews
         }
+        assertTrue("expected keyboard controls, got ${counts.first}", counts.first >= 30)
+        assertTrue("expected text nodes, got ${counts.second}", counts.second >= 3)
     }
 
     @Test
     fun keyboardExposesRootAndLayoutTags() {
-        rule.scenario.onActivity { activity ->
-            val root = activity.findViewById<ViewGroup>(android.R.id.content)
-            val imeRoot = root?.findViewWithTag<View>("ime_root")
-            assertNotNull(imeRoot)
-            assertTrue(imeRoot?.width ?: 0 > 0)
-            assertTrue(imeRoot?.height ?: 0 > 0)
-            assertNotNull(root?.findViewWithTag<View>("candidate-expand"))
-            assertNotNull(root?.findViewWithTag<View>("panel-overlay"))
-            assertNotNull(root?.findViewWithTag<View>("candidate-overlay"))
+        val nodes = harness.awaitMain { activity ->
+            val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
+            val imeRoot = root.findViewWithTag<View>("ime_root") ?: return@awaitMain null
+            if (imeRoot.width <= 0 || imeRoot.height <= 0) return@awaitMain null
+            listOf(
+                imeRoot,
+                root.findViewWithTag("candidate-expand"),
+                root.findViewWithTag("panel-overlay"),
+                root.findViewWithTag("candidate-overlay"),
+            ).takeIf { it.all { node -> node != null } }
         }
+        nodes.forEach(::assertNotNull)
     }
 
     @Test
     fun backspaceSwipeUpDispatchesOneShotClear() {
-        rule.scenario.onActivity { activity ->
-            val root = activity.findViewById<ViewGroup>(android.R.id.content)
-            val imeRoot = requireNotNull(root.findViewWithTag<View>("ime_root"))
-            val backspace = requireNotNull(root.findViewWithTag<View>("key-backspace"))
+        harness.awaitMain { activity ->
+            val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
+            val imeRoot = root.findViewWithTag<View>("ime_root") ?: return@awaitMain null
+            val backspace = root.findViewWithTag<View>("key-backspace") ?: return@awaitMain null
+            if (imeRoot.width <= 0 || backspace.width <= 0) return@awaitMain null
 
             val imeLocation = IntArray(2)
             val keyLocation = IntArray(2)
@@ -90,7 +110,10 @@ class DebugKeyboardActivityTest {
             dispatch(MotionEvent.ACTION_DOWN, y)
             dispatch(MotionEvent.ACTION_MOVE, upY)
             dispatch(MotionEvent.ACTION_UP, upY)
+            true
+        }
 
+        val found = harness.awaitMain { activity ->
             var clearStatusFound = false
             fun walk(view: View) {
                 if (view is TextView && view.text.toString() == "clear-all") clearStatusFound = true
@@ -98,8 +121,9 @@ class DebugKeyboardActivityTest {
                     for (index in 0 until view.childCount) walk(view.getChildAt(index))
                 }
             }
-            walk(root)
-            assertTrue("上滑松手必须只触发一次批量清空", clearStatusFound)
+            activity.findViewById<ViewGroup>(android.R.id.content)?.let(::walk)
+            clearStatusFound.takeIf { it }
         }
+        assertTrue("上滑松手必须只触发一次批量清空", found)
     }
 }

--- a/app/src/androidTest/java/llc/slacker/openime/DirectActivityHarness.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/DirectActivityHarness.kt
@@ -1,0 +1,99 @@
+package llc.slacker.openime
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import android.os.Bundle
+import android.os.SystemClock
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * OEM-safe activity launcher for instrumentation.
+ *
+ * ActivityScenario/startActivitySync wait for global main-thread idleness. Some
+ * MIUI builds keep Choreographer/window callbacks active while an IME-like view
+ * is visible, which can make that global-idle condition unreachable. This
+ * harness waits only for the lifecycle/UI condition the test actually needs.
+ */
+internal class DirectActivityHarness<T : Activity>(
+    private val activityClass: Class<T>,
+) : AutoCloseable {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val application = instrumentation.targetContext.applicationContext as Application
+    private val resumed = AtomicReference<T?>(null)
+
+    private val callbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityResumed(activity: Activity) {
+            if (activityClass.isInstance(activity)) {
+                @Suppress("UNCHECKED_CAST")
+                resumed.set(activity as T)
+            }
+        }
+
+        override fun onActivityDestroyed(activity: Activity) {
+            if (resumed.get() === activity) resumed.set(null)
+        }
+
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+        override fun onActivityStarted(activity: Activity) = Unit
+        override fun onActivityPaused(activity: Activity) = Unit
+        override fun onActivityStopped(activity: Activity) = Unit
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    }
+
+    init {
+        application.registerActivityLifecycleCallbacks(callbacks)
+    }
+
+    fun launch(timeoutMs: Long = 30_000L): T {
+        resumed.set(null)
+        instrumentation.targetContext.startActivity(
+            Intent(instrumentation.targetContext, activityClass).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            },
+        )
+        return await(timeoutMs) { resumed.get() }
+            ?: error("${activityClass.simpleName} did not resume within ${timeoutMs}ms")
+    }
+
+    fun <R : Any> awaitMain(
+        timeoutMs: Long = 30_000L,
+        probe: (T) -> R?,
+    ): R {
+        val deadline = SystemClock.uptimeMillis() + timeoutMs
+        while (SystemClock.uptimeMillis() < deadline) {
+            val activity = resumed.get()
+            if (activity != null) {
+                val result = AtomicReference<R?>(null)
+                instrumentation.runOnMainSync {
+                    result.set(probe(activity))
+                }
+                result.get()?.let { return it }
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+        error("UI condition for ${activityClass.simpleName} was not met within ${timeoutMs}ms")
+    }
+
+    private fun <R : Any> await(timeoutMs: Long, probe: () -> R?): R? {
+        val deadline = SystemClock.uptimeMillis() + timeoutMs
+        while (SystemClock.uptimeMillis() < deadline) {
+            probe()?.let { return it }
+            SystemClock.sleep(POLL_MS)
+        }
+        return null
+    }
+
+    override fun close() {
+        val activity = resumed.getAndSet(null)
+        if (activity != null && !activity.isFinishing) {
+            instrumentation.runOnMainSync { activity.finish() }
+        }
+        application.unregisterActivityLifecycleCallbacks(callbacks)
+    }
+
+    private companion object {
+        const val POLL_MS = 25L
+    }
+}

--- a/app/src/androidTest/java/llc/slacker/openime/RealUiInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/RealUiInstrumentedTest.kt
@@ -1,50 +1,41 @@
 package llc.slacker.openime
 
-import android.app.Activity
-import android.content.Intent
 import android.view.View
 import android.view.ViewGroup
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Real-device UI test that does not rely on ActivityScenarioRule.
- * Some MIUI builds block ActivityScenario startup, so this uses the
- * instrumentation's direct launch path.
+ * Real-device UI test that deliberately avoids global-idle synchronization.
+ * MIUI can keep window/Choreographer callbacks active while an IME-like view is
+ * visible, so the test waits only for the concrete rendered UI condition.
  */
 @RunWith(AndroidJUnit4::class)
 class RealUiInstrumentedTest {
 
     @Test
     fun realDeviceUiRendersKeyboard() {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val intent = Intent(instrumentation.targetContext, DebugKeyboardActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        val activity = instrumentation.startActivitySync(intent) as Activity
-        try {
-            var root: View? = null
-            var clickable = 0
-            instrumentation.runOnMainSync {
-                root = activity.findViewById(android.R.id.content)
+        DirectActivityHarness(DebugKeyboardActivity::class.java).use { harness ->
+            harness.launch()
+            val result = harness.awaitMain { activity ->
+                val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
                 var imeRoot: View? = null
+                var clickable = 0
                 fun walk(view: View) {
                     if (view.isClickable && view !is ImeKeyboardView) clickable++
                     if (view.tag == "ime_root") imeRoot = view
                     if (view is ViewGroup) {
-                        for (i in 0 until view.childCount) walk(view.getChildAt(i))
+                        for (index in 0 until view.childCount) walk(view.getChildAt(index))
                     }
                 }
-                root?.let(::walk)
-                assertNotNull("ime_root missing", imeRoot)
+                walk(root)
+                if (imeRoot == null || clickable < 30) null else imeRoot to clickable
             }
-            assertTrue("clickable controls missing: $clickable", clickable >= 30)
-        } finally {
-            instrumentation.runOnMainSync { activity.finish() }
+            assertNotNull("ime_root missing", result.first)
+            assertTrue("clickable controls missing: ${result.second}", result.second >= 30)
         }
     }
 }

--- a/app/src/androidTest/java/llc/slacker/openime/TextEditControlsInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/TextEditControlsInstrumentedTest.kt
@@ -39,20 +39,33 @@ class TextEditControlsInstrumentedTest {
 
         rule.scenario.onActivity {
             listOf("撤销", "▲", "▼").forEach { label ->
-                val control = findTextView(keyboard, label)
+                val control = findInteractiveControl(keyboard, label)
+                val labelView = findTextView(keyboard, label)
                 assertNotNull("missing disabled text-edit control $label", control)
+                assertNotNull("missing disabled text-edit label $label", labelView)
                 assertFalse("$label must not remain clickable", control!!.isClickable)
                 assertFalse("$label must expose disabled state", control.isEnabled)
-                assertTrue("$label should look unavailable", control.alpha < 1f)
+                assertTrue("$label should look unavailable", labelView!!.alpha < 1f)
             }
 
             listOf("全选", "复制", "剪切", "粘贴", "◀", "▶").forEach { label ->
-                val control = findTextView(keyboard, label)
+                val control = findInteractiveControl(keyboard, label)
                 assertNotNull("missing supported text-edit control $label", control)
                 assertTrue("$label should remain clickable", control!!.isClickable)
                 assertTrue("$label should remain enabled", control.isEnabled)
             }
         }
+    }
+
+    private fun findInteractiveControl(root: View, label: String): View? {
+        if (root is ImeKeyView && root.contentDescription?.toString() == label) return root
+        if (root is TextView && root.text.toString() == label && root.parent !is ImeKeyView) return root
+        if (root is ViewGroup) {
+            for (index in 0 until root.childCount) {
+                findInteractiveControl(root.getChildAt(index), label)?.let { return it }
+            }
+        }
+        return null
     }
 
     private fun findTextView(root: View, label: String): TextView? {


### PR DESCRIPTION
## Summary
- add a GitHub Actions emulator matrix for API 29 (Android 10) and API 31 (Android 12), running the full `connectedDebugAndroidTest` suite and uploading per-API reports
- replace `ActivityScenarioRule` / `startActivitySync` global-idle synchronization in the MIUI-sensitive keyboard UI tests with a direct activity harness based on lifecycle callbacks and bounded condition polling
- wait only for the concrete resumed/rendered condition each test needs, so persistent OEM Choreographer/window callbacks cannot keep the test blocked forever
- add compatibility smoke coverage for P+ Unicode code-point deletion, sensitive clipboard rejection, bundled candidate lookup, and the fresh-device microphone-permission failure path
- disable emulator animations in compatibility CI and keep API jobs independent with `fail-fast: false`

## Validation
- Build/unit/lint CI pending
- API 29 compatibility emulator CI pending
- API 31 compatibility emulator CI pending
- T8 must remain PARTIAL until both compatibility jobs are green; after that the workflow artifacts provide the concrete API/device evidence

Closes #37