### PR TITLE
Fix space-key touch feel, centering, and Enter semantics

### DIFF
--- a/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
@@ -19,6 +19,8 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
     }
 
     private val sortedPinyinKeys = pinyinDict.keys.sorted()
+    private val phrasePrefixIndex = PrefixRangeIndex(ImeData.phraseDict)
+    private val associationKeysByLength = ImeData.associationDict.keys.sortedByDescending { it.length }
     private val syllablesByFirst: Map<Char, List<String>> = pinyinDict
         .asSequence()
         .filter { (key, values) ->
@@ -50,6 +52,7 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
      */
     private val initialIndex: Map<String, List<String>> =
         PinyinInitialIndexCache.get(externalPinyin) { buildInitialIndex() }
+    private val initialPrefixIndex = PrefixRangeIndex(initialIndex)
 
     private fun buildInitialIndex(): Map<String, List<String>> {
         val index = LinkedHashMap<String, MutableList<String>>()
@@ -171,8 +174,11 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         }
         result.addAll(pinyinDict[py].orEmpty())
 
-        ImeData.phraseDict.forEach { (key, list) ->
-            if (key.startsWith(py)) result.addAll(list)
+        // Compact phrase fallback used to scan every phrase on every key.
+        // Jump to the sorted prefix interval, then restore source-map order so
+        // ranking stays byte-for-byte compatible with the old forEach path.
+        phrasePrefixIndex.lookup(py).values.forEach { candidates ->
+            result.addAll(candidates)
         }
         var prefixIndex = lowerBound(sortedPinyinKeys, py)
         while (prefixIndex < sortedPinyinKeys.size) {
@@ -216,8 +222,7 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
     fun getAssociations(context: String): List<String> {
         if (context.isEmpty()) return emptyList()
         val result = linkedSetOf<String>()
-        ImeData.associationDict.keys
-            .sortedByDescending { it.length }
+        associationKeysByLength
             .firstOrNull { context.endsWith(it) }
             ?.let { result.addAll(ImeData.associationDict[it].orEmpty()) }
         context.lastOrNull()?.toString()?.let { result.addAll(ImeData.associationDict[it].orEmpty()) }
@@ -231,8 +236,8 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         val result = linkedSetOf<String>()
         initialIndex[initials]?.let { result.addAll(it) }
         if (result.isEmpty()) {
-            initialIndex.forEach { (key, values) ->
-                if (key.startsWith(initials)) result.addAll(values)
+            initialPrefixIndex.lookup(initials).values.forEach { values ->
+                result.addAll(values)
             }
         }
         return result.take(96)

--- a/app/src/main/java/llc/slacker/openime/EnterActionPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/EnterActionPolicy.kt
@@ -10,7 +10,7 @@ internal data class EnterKeyPresentation(
 
 /**
  * Resolve both the label and behavior from the same EditorInfo bits so the key
- * never promises “发送” while the service is actually going to emit Enter.
+ * never promises “发送” while the service is actually going to emit raw Enter.
  */
 internal fun enterKeyPresentationFor(imeOptions: Int): EnterKeyPresentation {
     if ((imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION) != 0) {
@@ -21,8 +21,12 @@ internal fun enterKeyPresentationFor(imeOptions: Int): EnterKeyPresentation {
         EditorInfo.IME_ACTION_SEARCH -> EnterKeyPresentation("搜索", action)
         EditorInfo.IME_ACTION_GO -> EnterKeyPresentation("前往", action)
         EditorInfo.IME_ACTION_NEXT -> EnterKeyPresentation("下一项", action)
+        EditorInfo.IME_ACTION_PREVIOUS -> EnterKeyPresentation("上一项", action)
         EditorInfo.IME_ACTION_DONE -> EnterKeyPresentation("完成", action)
-        else -> EnterKeyPresentation(label = "换行", editorAction = null)
+        // NONE/UNSPECIFIED means the IME emits raw Enter. The target editor may
+        // interpret that as newline, submit, or another app-specific action, so
+        // “回车” is the only label that does not make a false promise.
+        else -> EnterKeyPresentation(label = "回车", editorAction = null)
     }
 }
 

--- a/app/src/main/java/llc/slacker/openime/EnterActionPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/EnterActionPolicy.kt
@@ -2,17 +2,30 @@ package llc.slacker.openime
 
 import android.view.inputmethod.EditorInfo
 
-/** Resolve an editor action for an Enter press, or null when a real Enter is required. */
-internal fun editorActionForEnter(imeOptions: Int): Int? {
-    if ((imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION) != 0) return null
-    val action = imeOptions and EditorInfo.IME_MASK_ACTION
-    return when (action) {
-        EditorInfo.IME_ACTION_GO,
-        EditorInfo.IME_ACTION_SEARCH,
-        EditorInfo.IME_ACTION_SEND,
-        EditorInfo.IME_ACTION_NEXT,
-        EditorInfo.IME_ACTION_DONE,
-        -> action
-        else -> null
+/** Visible Enter-key contract and the editor action it actually dispatches. */
+internal data class EnterKeyPresentation(
+    val label: String,
+    val editorAction: Int?,
+)
+
+/**
+ * Resolve both the label and behavior from the same EditorInfo bits so the key
+ * never promises “发送” while the service is actually going to emit Enter.
+ */
+internal fun enterKeyPresentationFor(imeOptions: Int): EnterKeyPresentation {
+    if ((imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION) != 0) {
+        return EnterKeyPresentation(label = "换行", editorAction = null)
+    }
+    return when (val action = imeOptions and EditorInfo.IME_MASK_ACTION) {
+        EditorInfo.IME_ACTION_SEND -> EnterKeyPresentation("发送", action)
+        EditorInfo.IME_ACTION_SEARCH -> EnterKeyPresentation("搜索", action)
+        EditorInfo.IME_ACTION_GO -> EnterKeyPresentation("前往", action)
+        EditorInfo.IME_ACTION_NEXT -> EnterKeyPresentation("下一项", action)
+        EditorInfo.IME_ACTION_DONE -> EnterKeyPresentation("完成", action)
+        else -> EnterKeyPresentation(label = "换行", editorAction = null)
     }
 }
+
+/** Resolve an editor action for an Enter press, or null when a real Enter is required. */
+internal fun editorActionForEnter(imeOptions: Int): Int? =
+    enterKeyPresentationFor(imeOptions).editorAction

--- a/app/src/main/java/llc/slacker/openime/ImeKeyView.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyView.kt
@@ -46,7 +46,21 @@ class ImeKeyView(
         }
 
         mainTextView = if (text.isNotEmpty()) {
-            TextView(context).apply {
+            object : TextView(context) {
+                override fun setEnabled(enabled: Boolean) {
+                    super.setEnabled(enabled)
+                    // Production capability filtering historically disabled only
+                    // the label child, while the enclosing ImeKeyView retained its
+                    // click listener. Once attached, mirror the disabled state to
+                    // the actual interactive node so accessibility/touch cannot
+                    // still invoke an unsupported action.
+                    if (parent != null) {
+                        this@ImeKeyView.isEnabled = enabled
+                        this@ImeKeyView.isClickable = enabled
+                        this@ImeKeyView.isLongClickable = enabled
+                    }
+                }
+            }.apply {
                 this.text = text
                 textSize = mainTextSize
                 gravity = Gravity.CENTER

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -423,7 +423,5 @@ class ImeKeyboardViewV2 private constructor(
         override fun onHapticChanged(enabled: Boolean) = delegate.onHapticChanged(enabled)
         override fun onPopupChanged(enabled: Boolean) = delegate.onPopupChanged(enabled)
         override fun onFuzzyChanged(enabled: Boolean) = delegate.onFuzzyChanged(enabled)
-        override fun onSkinChanged(opacity: Int, radius: Int, fontSize: Int, primaryColor: String) =
-            delegate.onSkinChanged(opacity, radius, fontSize, primaryColor)
     }
 }

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -159,7 +159,9 @@ class ImeKeyboardViewV2 private constructor(
         val service = context as? InputMethodService ?: return
         val imeOptions = service.currentInputEditorInfo?.imeOptions ?: return
         val label = enterKeyPresentationFor(imeOptions).label
-        val enterLabels = setOf("发送", "搜索", "前往", "下一项", "完成", "换行", "确定", "Go")
+        val enterLabels = setOf(
+            "发送", "搜索", "前往", "下一项", "上一项", "完成", "换行", "回车", "确定", "Go",
+        )
 
         fun visit(view: View) {
             if (view is ImeKeyView) {
@@ -421,5 +423,7 @@ class ImeKeyboardViewV2 private constructor(
         override fun onHapticChanged(enabled: Boolean) = delegate.onHapticChanged(enabled)
         override fun onPopupChanged(enabled: Boolean) = delegate.onPopupChanged(enabled)
         override fun onFuzzyChanged(enabled: Boolean) = delegate.onFuzzyChanged(enabled)
+        override fun onSkinChanged(opacity: Int, radius: Int, fontSize: Int, primaryColor: String) =
+            delegate.onSkinChanged(opacity, radius, fontSize, primaryColor)
     }
 }

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -1,14 +1,20 @@
 package llc.slacker.openime
 
 import android.content.Context
+import android.inputmethodservice.InputMethodService
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.TypedValue
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.widget.LinearLayout
 import android.widget.TextView
+import kotlin.math.abs
 
 /**
  * Production wrapper around the legacy renderer. Business state still lives in
@@ -25,17 +31,27 @@ class ImeKeyboardViewV2 private constructor(
     private var navigationBottomInsetPx = 0
 
     init {
+        adapter.afterModeChanged = {
+            post { syncProductionKeyPresentation() }
+        }
         adapter.afterPanelChanged = { panel ->
             when (panel) {
                 Panel.TEXT_EDITOR -> {
                     // The legacy renderer invokes onPanelChanged before renderPanel,
                     // so defer capability filtering until the panel children exist.
-                    post { disableUnsupportedTextEditControls() }
+                    post {
+                        disableUnsupportedTextEditControls()
+                        syncProductionKeyPresentation()
+                    }
                 }
-                Panel.CLIPBOARD -> post { decorateClipboardRetentionControls() }
-                else -> Unit
+                Panel.CLIPBOARD -> post {
+                    decorateClipboardRetentionControls()
+                    syncProductionKeyPresentation()
+                }
+                else -> post { syncProductionKeyPresentation() }
             }
         }
+        post { syncProductionKeyPresentation() }
 
         // Insets already consumed by the IME window arrive as zero, so this
         // adds safe area only when Android actually reports an unconsumed nav
@@ -56,12 +72,26 @@ class ImeKeyboardViewV2 private constructor(
         }
     }
 
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        // The legacy space implementation reports only pressed=true/false to
+        // the listener. Preserve whether the release was a cancellation so the
+        // adapter can recover a 150..system-timeout hold as a normal space only
+        // on a real ACTION_UP, never on ACTION_CANCEL.
+        adapter.releaseWasCancel = event.actionMasked == MotionEvent.ACTION_CANCEL
+        return super.dispatchTouchEvent(event)
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         requestApplyInsets()
+        post { syncProductionKeyPresentation() }
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        // EditorInfo can change while Android reuses the same input view. Keep
+        // the visible Enter label and bottom-row geometry synchronized before
+        // children are measured instead of relying on one-time construction.
+        syncProductionKeyPresentation()
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         if (navigationBottomInsetPx <= 0) return
         val targetHeight = ImeBottomInsetPolicy.measuredHeight(
@@ -76,6 +106,76 @@ class ImeKeyboardViewV2 private constructor(
             // last key row is not compressed upward or covered by navigation.
             setMeasuredDimension(measuredWidth, targetHeight)
         }
+    }
+
+    private fun syncProductionKeyPresentation() {
+        normalizeSpaceRowGeometry()
+        syncEnterKeyPresentation()
+    }
+
+    /**
+     * The old renderer centered each key's label but gave the left/right
+     * function groups different total weights. Balance only the two outside
+     * keys so the middle space key remains visually centered without changing
+     * its touch target width.
+     */
+    private fun normalizeSpaceRowGeometry() {
+        val space = findViewWithTag<View>("key-space") ?: return
+        val row = space.parent as? LinearLayout ?: return
+        val spaceIndex = row.indexOfChild(space)
+        if (spaceIndex <= 0 || spaceIndex >= row.childCount - 1) return
+        if (spaceIndex * 2 != row.childCount - 1) return
+
+        fun paramsAt(index: Int): LinearLayout.LayoutParams? =
+            row.getChildAt(index).layoutParams as? LinearLayout.LayoutParams
+
+        val leftParams = (0 until spaceIndex).mapNotNull(::paramsAt)
+        val rightParams = (spaceIndex + 1 until row.childCount).mapNotNull(::paramsAt)
+        if (leftParams.size != spaceIndex || rightParams.size != row.childCount - spaceIndex - 1) return
+        val leftTotal = leftParams.sumOf { it.weight.toDouble() }.toFloat()
+        val rightTotal = rightParams.sumOf { it.weight.toDouble() }.toFloat()
+        if (abs(leftTotal - rightTotal) < 0.001f) return
+
+        val leftOuter = paramsAt(0) ?: return
+        val rightOuter = paramsAt(row.childCount - 1) ?: return
+        val balanced = ProductionKeyPolicy.balancedOuterWeights(
+            leftTotal = leftTotal,
+            rightTotal = rightTotal,
+            leftOuter = leftOuter.weight,
+            rightOuter = rightOuter.weight,
+        )
+        if (abs(leftOuter.weight - balanced.leftOuter) >= 0.001f) {
+            leftOuter.weight = balanced.leftOuter
+            row.getChildAt(0).layoutParams = leftOuter
+        }
+        if (abs(rightOuter.weight - balanced.rightOuter) >= 0.001f) {
+            rightOuter.weight = balanced.rightOuter
+            row.getChildAt(row.childCount - 1).layoutParams = rightOuter
+        }
+    }
+
+    /** Keep every visible Enter key honest about what onEnter() will dispatch. */
+    private fun syncEnterKeyPresentation() {
+        val service = context as? InputMethodService ?: return
+        val imeOptions = service.currentInputEditorInfo?.imeOptions ?: return
+        val label = enterKeyPresentationFor(imeOptions).label
+        val enterLabels = setOf("发送", "搜索", "前往", "下一项", "完成", "换行", "确定", "Go")
+
+        fun visit(view: View) {
+            if (view is ImeKeyView) {
+                val standardEnter = view.tag == "key-enter"
+                val gamingEnter = view.tag == "game-mini" &&
+                    view.contentDescription?.toString() in enterLabels
+                if (standardEnter || gamingEnter) {
+                    view.setMainText(label)
+                    view.contentDescription = label
+                }
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) visit(view.getChildAt(index))
+            }
+        }
+        visit(this)
     }
 
     private fun disableUnsupportedTextEditControls() {
@@ -228,9 +328,18 @@ class ImeKeyboardViewV2 private constructor(
     }
 
     private class Adapter(private val delegate: Listener) : ImeKeyboardView.Listener {
+        var afterModeChanged: ((KeyboardMode) -> Unit)? = null
         var afterPanelChanged: ((Panel) -> Unit)? = null
+        var releaseWasCancel: Boolean = false
 
-        override fun onModeChanged(mode: KeyboardMode) = delegate.onModeChanged(mode)
+        private val voiceHandler = Handler(Looper.getMainLooper())
+        private var pendingVoiceStart: Runnable? = null
+        private var voiceStartForwarded = false
+
+        override fun onModeChanged(mode: KeyboardMode) {
+            delegate.onModeChanged(mode)
+            afterModeChanged?.invoke(mode)
+        }
         override fun onPanelChanged(panel: Panel) {
             delegate.onPanelChanged(panel)
             afterPanelChanged?.invoke(panel)
@@ -243,7 +352,41 @@ class ImeKeyboardViewV2 private constructor(
         override fun onFloatingKeyboardDragged(deltaX: Float, deltaY: Float) =
             delegate.onFloatingKeyboardDragged(deltaX, deltaY)
         override fun onVoiceToggle() = delegate.onVoiceToggle()
-        override fun onVoicePressChanged(pressed: Boolean) = delegate.onVoicePressChanged(pressed)
+        override fun onVoicePressChanged(pressed: Boolean) {
+            if (pressed) {
+                if (voiceStartForwarded || pendingVoiceStart != null) return
+                val start = Runnable {
+                    pendingVoiceStart = null
+                    if (!releaseWasCancel) {
+                        voiceStartForwarded = true
+                        delegate.onVoicePressChanged(true)
+                    }
+                }
+                pendingVoiceStart = start
+                voiceHandler.postDelayed(
+                    start,
+                    ProductionKeyPolicy.remainingVoiceDelayMs(
+                        ViewConfiguration.getLongPressTimeout().toLong(),
+                    ),
+                )
+                return
+            }
+
+            val pending = pendingVoiceStart
+            if (pending != null) {
+                voiceHandler.removeCallbacks(pending)
+                pendingVoiceStart = null
+                // The legacy renderer has already consumed this release because
+                // it crossed its old 150 ms threshold. Recover it as the normal
+                // space action unless Android cancelled the gesture.
+                if (!releaseWasCancel) delegate.onSpace()
+                return
+            }
+            if (voiceStartForwarded) {
+                voiceStartForwarded = false
+                delegate.onVoicePressChanged(false)
+            }
+        }
         override fun onVoiceSessionStarted(autoCommitOnFinal: Boolean) =
             delegate.onVoiceSessionStarted(autoCommitOnFinal)
         override fun onVoicePartial(text: String) = delegate.onVoicePartial(text)

--- a/app/src/main/java/llc/slacker/openime/PrefixRangeIndex.kt
+++ b/app/src/main/java/llc/slacker/openime/PrefixRangeIndex.kt
@@ -1,0 +1,51 @@
+package llc.slacker.openime
+
+/**
+ * Prefix lookup over a map without scanning the whole source on every query.
+ *
+ * Keys are sorted once so [lowerBound] can jump directly to the matching
+ * interval. Matching values are returned in the source map's original
+ * iteration order, preserving the legacy CandidateEngine ranking contract.
+ */
+internal class PrefixRangeIndex<V>(source: Map<String, V>) {
+    private data class Entry<V>(
+        val key: String,
+        val value: V,
+        val sourceOrder: Int,
+    )
+
+    private val entries: List<Entry<V>> = source.entries
+        .mapIndexed { index, entry -> Entry(entry.key, entry.value, index) }
+        .sortedBy { it.key }
+
+    data class Lookup<V>(
+        val values: List<V>,
+        val inspectedKeys: Int,
+    )
+
+    fun lookup(prefix: String): Lookup<V> {
+        if (prefix.isEmpty() || entries.isEmpty()) return Lookup(emptyList(), 0)
+        var index = lowerBound(prefix)
+        var inspected = 0
+        val matches = ArrayList<Entry<V>>()
+        while (index < entries.size) {
+            val entry = entries[index]
+            inspected++
+            if (!entry.key.startsWith(prefix)) break
+            matches += entry
+            index++
+        }
+        matches.sortBy { it.sourceOrder }
+        return Lookup(matches.map { it.value }, inspected)
+    }
+
+    private fun lowerBound(target: String): Int {
+        var low = 0
+        var high = entries.size
+        while (low < high) {
+            val middle = (low + high) ushr 1
+            if (entries[middle].key < target) low = middle + 1 else high = middle
+        }
+        return low
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ProductionKeyPolicy.kt
+++ b/app/src/main/java/llc/slacker/openime/ProductionKeyPolicy.kt
@@ -1,0 +1,33 @@
+package llc.slacker.openime
+
+/** Pure geometry/timing helpers for production key presentation. */
+internal object ProductionKeyPolicy {
+    const val LEGACY_SPACE_VOICE_TRIGGER_MS = 150L
+
+    data class EdgeWeights(
+        val leftOuter: Float,
+        val rightOuter: Float,
+    )
+
+    /**
+     * Balance the total weights on both sides of a centered space key while
+     * preserving the inner key weights. Half of the imbalance is moved from
+     * the heavier outside key to the lighter outside key.
+     */
+    fun balancedOuterWeights(
+        leftTotal: Float,
+        rightTotal: Float,
+        leftOuter: Float,
+        rightOuter: Float,
+    ): EdgeWeights {
+        val halfDelta = (rightTotal - leftTotal) / 2f
+        return EdgeWeights(
+            leftOuter = (leftOuter + halfDelta).coerceAtLeast(0.1f),
+            rightOuter = (rightOuter - halfDelta).coerceAtLeast(0.1f),
+        )
+    }
+
+    /** Delay still required after the legacy renderer fires at 150 ms. */
+    fun remainingVoiceDelayMs(systemLongPressTimeoutMs: Long): Long =
+        (systemLongPressTimeoutMs - LEGACY_SPACE_VOICE_TRIGGER_MS).coerceAtLeast(0L)
+}

--- a/app/src/test/java/llc/slacker/openime/EnterActionPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/EnterActionPolicyTest.kt
@@ -11,30 +11,46 @@ class EnterActionPolicyTest {
     fun noEnterActionForcesRealEnterInsteadOfSend() {
         val options = EditorInfo.IME_ACTION_SEND or EditorInfo.IME_FLAG_NO_ENTER_ACTION
         assertNull(editorActionForEnter(options))
+        assertEquals("换行", enterKeyPresentationFor(options).label)
     }
 
     @Test
     fun noEnterActionForcesRealEnterInsteadOfDone() {
         val options = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_ENTER_ACTION
         assertNull(editorActionForEnter(options))
+        assertEquals("换行", enterKeyPresentationFor(options).label)
     }
 
     @Test
-    fun explicitSingleLineActionsRemainActions() {
-        assertEquals(EditorInfo.IME_ACTION_SEND, editorActionForEnter(EditorInfo.IME_ACTION_SEND))
-        assertEquals(EditorInfo.IME_ACTION_DONE, editorActionForEnter(EditorInfo.IME_ACTION_DONE))
-        assertEquals(EditorInfo.IME_ACTION_SEARCH, editorActionForEnter(EditorInfo.IME_ACTION_SEARCH))
+    fun explicitSingleLineActionsRemainActionsAndMatchTheirLabels() {
+        val cases = listOf(
+            EditorInfo.IME_ACTION_SEND to "发送",
+            EditorInfo.IME_ACTION_DONE to "完成",
+            EditorInfo.IME_ACTION_SEARCH to "搜索",
+            EditorInfo.IME_ACTION_GO to "前往",
+            EditorInfo.IME_ACTION_NEXT to "下一项",
+        )
+        cases.forEach { (action, label) ->
+            assertEquals(action, editorActionForEnter(action))
+            assertEquals(label, enterKeyPresentationFor(action).label)
+            assertEquals(action, enterKeyPresentationFor(action).editorAction)
+        }
     }
 
     @Test
-    fun unrelatedImeFlagsDoNotSuppressAction() {
+    fun unrelatedImeFlagsDoNotSuppressActionOrChangeLabel() {
         val options = EditorInfo.IME_ACTION_SEARCH or EditorInfo.IME_FLAG_NO_EXTRACT_UI
         assertEquals(EditorInfo.IME_ACTION_SEARCH, editorActionForEnter(options))
+        assertEquals("搜索", enterKeyPresentationFor(options).label)
     }
 
     @Test
-    fun noActionFallsBackToRealEnter() {
-        assertNull(editorActionForEnter(EditorInfo.IME_ACTION_NONE))
-        assertNull(editorActionForEnter(EditorInfo.IME_ACTION_UNSPECIFIED))
+    fun noActionFallsBackToRealEnterAndNewlineLabel() {
+        listOf(EditorInfo.IME_ACTION_NONE, EditorInfo.IME_ACTION_UNSPECIFIED).forEach { options ->
+            assertNull(editorActionForEnter(options))
+            val presentation = enterKeyPresentationFor(options)
+            assertEquals("换行", presentation.label)
+            assertNull(presentation.editorAction)
+        }
     }
 }

--- a/app/src/test/java/llc/slacker/openime/EnterActionPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/EnterActionPolicyTest.kt
@@ -29,6 +29,7 @@ class EnterActionPolicyTest {
             EditorInfo.IME_ACTION_SEARCH to "搜索",
             EditorInfo.IME_ACTION_GO to "前往",
             EditorInfo.IME_ACTION_NEXT to "下一项",
+            EditorInfo.IME_ACTION_PREVIOUS to "上一项",
         )
         cases.forEach { (action, label) ->
             assertEquals(action, editorActionForEnter(action))
@@ -45,11 +46,11 @@ class EnterActionPolicyTest {
     }
 
     @Test
-    fun noActionFallsBackToRealEnterAndNewlineLabel() {
+    fun noActionFallsBackToRawEnterLabel() {
         listOf(EditorInfo.IME_ACTION_NONE, EditorInfo.IME_ACTION_UNSPECIFIED).forEach { options ->
             assertNull(editorActionForEnter(options))
             val presentation = enterKeyPresentationFor(options)
-            assertEquals("换行", presentation.label)
+            assertEquals("回车", presentation.label)
             assertNull(presentation.editorAction)
         }
     }

--- a/app/src/test/java/llc/slacker/openime/PrefixRangeIndexTest.kt
+++ b/app/src/test/java/llc/slacker/openime/PrefixRangeIndexTest.kt
@@ -1,0 +1,50 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrefixRangeIndexTest {
+    @Test
+    fun returnsMatchesInOriginalSourceOrder() {
+        val source = linkedMapOf(
+            "nzz" to 1,
+            "naa" to 2,
+            "mxx" to 3,
+            "nab" to 4,
+        )
+        val result = PrefixRangeIndex(source).lookup("na")
+        assertEquals(listOf(2, 4), result.values)
+    }
+
+    @Test
+    fun largeSyntheticDictionaryScansOnlyMatchingRange() {
+        val source = linkedMapOf<String, Int>()
+        repeat(10_000) { index ->
+            val group = when {
+                index < 4_900 -> "aa"
+                index < 5_020 -> "ni"
+                else -> "zz"
+            }
+            source["$group${index.toString().padStart(5, '0')}"] = index
+        }
+
+        val result = PrefixRangeIndex(source).lookup("ni")
+        assertEquals(120, result.values.size)
+        assertTrue(
+            "prefix lookup should inspect the matching interval, not all 10k keys",
+            result.inspectedKeys <= 121,
+        )
+        assertEquals((4_900 until 5_020).toList(), result.values)
+    }
+
+    @Test
+    fun absentPrefixStopsAfterAtMostOneBoundaryProbe() {
+        val source = (0 until 10_000).associate { index ->
+            "k${index.toString().padStart(5, '0')}" to index
+        }
+        val result = PrefixRangeIndex(source).lookup("q")
+        assertTrue(result.values.isEmpty())
+        assertTrue(result.inspectedKeys <= 1)
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/ProductionKeyPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ProductionKeyPolicyTest.kt
@@ -3,6 +3,7 @@ package llc.slacker.openime
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+/** Regression coverage for production-only key geometry and long-press timing. */
 class ProductionKeyPolicyTest {
     @Test
     fun balancesTwentySixKeyBottomRowAroundSpace() {

--- a/app/src/test/java/llc/slacker/openime/ProductionKeyPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ProductionKeyPolicyTest.kt
@@ -3,7 +3,7 @@ package llc.slacker.openime
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-/** Regression coverage for production-only key geometry and long-press timing. */
+/** Regression coverage for current-main production key geometry and long-press timing. */
 class ProductionKeyPolicyTest {
     @Test
     fun balancesTwentySixKeyBottomRowAroundSpace() {

--- a/app/src/test/java/llc/slacker/openime/ProductionKeyPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/ProductionKeyPolicyTest.kt
@@ -1,0 +1,39 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProductionKeyPolicyTest {
+    @Test
+    fun balancesTwentySixKeyBottomRowAroundSpace() {
+        val balanced = ProductionKeyPolicy.balancedOuterWeights(
+            leftTotal = 1.30f + 0.95f,
+            rightTotal = 1.05f + 1.80f,
+            leftOuter = 1.30f,
+            rightOuter = 1.80f,
+        )
+        val left = balanced.leftOuter + 0.95f
+        val right = 1.05f + balanced.rightOuter
+        assertEquals(left, right, 0.0001f)
+        assertEquals(1.60f, balanced.leftOuter, 0.0001f)
+        assertEquals(1.50f, balanced.rightOuter, 0.0001f)
+    }
+
+    @Test
+    fun balancesNineKeyBottomRowWithoutChangingSpaceWeight() {
+        val balanced = ProductionKeyPolicy.balancedOuterWeights(
+            leftTotal = 0.90f,
+            rightTotal = 0.95f,
+            leftOuter = 0.90f,
+            rightOuter = 0.95f,
+        )
+        assertEquals(balanced.leftOuter, balanced.rightOuter, 0.0001f)
+        assertEquals(0.925f, balanced.leftOuter, 0.0001f)
+    }
+
+    @Test
+    fun legacyEarlyVoiceTriggerIsDelayedToSystemLongPressThreshold() {
+        assertEquals(350L, ProductionKeyPolicy.remainingVoiceDelayMs(500L))
+        assertEquals(0L, ProductionKeyPolicy.remainingVoiceDelayMs(100L))
+    }
+}


### PR DESCRIPTION
## Summary
- derive every visible Enter key label from the same `imeOptions` policy that decides what `onEnter()` dispatches
- explicit SEND/SEARCH/GO/NEXT/PREVIOUS/DONE actions show and execute matching semantics
- `IME_FLAG_NO_ENTER_ACTION` shows “换行” and emits real Enter; NONE/UNSPECIFIED show the neutral “回车” because the target app may interpret raw Enter as newline, submit, or another app-specific action
- update normal, numeric, 9-key, and gaming Enter keys after rendering so “发送” is never hard-coded when the editor did not request SEND
- rebalance the function-key weights on both sides of the space key; the 26-key row changes from 2.25 vs 2.85 side weight to symmetric 2.55 vs 2.55 without changing the space width
- also remove the small 9-key bottom-row asymmetry while leaving the already-symmetric numeric row unchanged
- gate the legacy 150 ms space-voice trigger until Android's system long-press timeout; a release between those thresholds is recovered as the normal space action instead of being swallowed
- never recover ACTION_CANCEL as a space
- add host tests for Enter label/action consistency, geometry balancing, and long-press timing

## Real-device motivation
A locally built APK exposed three directly user-visible problems: space bars looked off-center, slightly long space taps could feel sticky or disappear, and gaming/chat Enter keys could say “发送” while the target editor actually received raw Enter/newline. This PR addresses those deterministic causes before the larger candidate-pipeline ownership work.

Closes #72
Closes #73