### PR TITLE
Index CandidateEngine prefix fallback hot paths

### DIFF
--- a/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
@@ -19,6 +19,8 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
     }
 
     private val sortedPinyinKeys = pinyinDict.keys.sorted()
+    private val phrasePrefixIndex = PrefixRangeIndex(ImeData.phraseDict)
+    private val associationKeysByLength = ImeData.associationDict.keys.sortedByDescending { it.length }
     private val syllablesByFirst: Map<Char, List<String>> = pinyinDict
         .asSequence()
         .filter { (key, values) ->
@@ -50,6 +52,7 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
      */
     private val initialIndex: Map<String, List<String>> =
         PinyinInitialIndexCache.get(externalPinyin) { buildInitialIndex() }
+    private val initialPrefixIndex = PrefixRangeIndex(initialIndex)
 
     private fun buildInitialIndex(): Map<String, List<String>> {
         val index = LinkedHashMap<String, MutableList<String>>()
@@ -171,8 +174,11 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         }
         result.addAll(pinyinDict[py].orEmpty())
 
-        ImeData.phraseDict.forEach { (key, list) ->
-            if (key.startsWith(py)) result.addAll(list)
+        // Compact phrase fallback used to scan every phrase on every key.
+        // Jump to the sorted prefix interval, then restore source-map order so
+        // ranking stays byte-for-byte compatible with the old forEach path.
+        phrasePrefixIndex.lookup(py).values.forEach { candidates ->
+            result.addAll(candidates)
         }
         var prefixIndex = lowerBound(sortedPinyinKeys, py)
         while (prefixIndex < sortedPinyinKeys.size) {
@@ -216,8 +222,7 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
     fun getAssociations(context: String): List<String> {
         if (context.isEmpty()) return emptyList()
         val result = linkedSetOf<String>()
-        ImeData.associationDict.keys
-            .sortedByDescending { it.length }
+        associationKeysByLength
             .firstOrNull { context.endsWith(it) }
             ?.let { result.addAll(ImeData.associationDict[it].orEmpty()) }
         context.lastOrNull()?.toString()?.let { result.addAll(ImeData.associationDict[it].orEmpty()) }
@@ -231,8 +236,8 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         val result = linkedSetOf<String>()
         initialIndex[initials]?.let { result.addAll(it) }
         if (result.isEmpty()) {
-            initialIndex.forEach { (key, values) ->
-                if (key.startsWith(initials)) result.addAll(values)
+            initialPrefixIndex.lookup(initials).values.forEach { values ->
+                result.addAll(values)
             }
         }
         return result.take(96)

--- a/app/src/main/java/llc/slacker/openime/PrefixRangeIndex.kt
+++ b/app/src/main/java/llc/slacker/openime/PrefixRangeIndex.kt
@@ -1,0 +1,51 @@
+package llc.slacker.openime
+
+/**
+ * Prefix lookup over a map without scanning the whole source on every query.
+ *
+ * Keys are sorted once so [lowerBound] can jump directly to the matching
+ * interval. Matching values are returned in the source map's original
+ * iteration order, preserving the legacy CandidateEngine ranking contract.
+ */
+internal class PrefixRangeIndex<V>(source: Map<String, V>) {
+    private data class Entry<V>(
+        val key: String,
+        val value: V,
+        val sourceOrder: Int,
+    )
+
+    private val entries: List<Entry<V>> = source.entries
+        .mapIndexed { index, entry -> Entry(entry.key, entry.value, index) }
+        .sortedBy { it.key }
+
+    data class Lookup<V>(
+        val values: List<V>,
+        val inspectedKeys: Int,
+    )
+
+    fun lookup(prefix: String): Lookup<V> {
+        if (prefix.isEmpty() || entries.isEmpty()) return Lookup(emptyList(), 0)
+        var index = lowerBound(prefix)
+        var inspected = 0
+        val matches = ArrayList<Entry<V>>()
+        while (index < entries.size) {
+            val entry = entries[index]
+            inspected++
+            if (!entry.key.startsWith(prefix)) break
+            matches += entry
+            index++
+        }
+        matches.sortBy { it.sourceOrder }
+        return Lookup(matches.map { it.value }, inspected)
+    }
+
+    private fun lowerBound(target: String): Int {
+        var low = 0
+        var high = entries.size
+        while (low < high) {
+            val middle = (low + high) ushr 1
+            if (entries[middle].key < target) low = middle + 1 else high = middle
+        }
+        return low
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/PrefixRangeIndexTest.kt
+++ b/app/src/test/java/llc/slacker/openime/PrefixRangeIndexTest.kt
@@ -1,0 +1,50 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrefixRangeIndexTest {
+    @Test
+    fun returnsMatchesInOriginalSourceOrder() {
+        val source = linkedMapOf(
+            "nzz" to 1,
+            "naa" to 2,
+            "mxx" to 3,
+            "nab" to 4,
+        )
+        val result = PrefixRangeIndex(source).lookup("na")
+        assertEquals(listOf(2, 4), result.values)
+    }
+
+    @Test
+    fun largeSyntheticDictionaryScansOnlyMatchingRange() {
+        val source = linkedMapOf<String, Int>()
+        repeat(10_000) { index ->
+            val group = when {
+                index < 4_900 -> "aa"
+                index < 5_020 -> "ni"
+                else -> "zz"
+            }
+            source["$group${index.toString().padStart(5, '0')}"] = index
+        }
+
+        val result = PrefixRangeIndex(source).lookup("ni")
+        assertEquals(120, result.values.size)
+        assertTrue(
+            "prefix lookup should inspect the matching interval, not all 10k keys",
+            result.inspectedKeys <= 121,
+        )
+        assertEquals((4_900 until 5_020).toList(), result.values)
+    }
+
+    @Test
+    fun absentPrefixStopsAfterAtMostOneBoundaryProbe() {
+        val source = (0 until 10_000).associate { index ->
+            "k${index.toString().padStart(5, '0')}" to index
+        }
+        val result = PrefixRangeIndex(source).lookup("q")
+        assertTrue(result.values.isEmpty())
+        assertTrue(result.inspectedKeys <= 1)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the per-key full `ImeData.phraseDict.forEach { startsWith(prefix) }` fallback scan with a sorted prefix-range index
- preserve the phrase dictionary's original iteration order after lowerBound range lookup so candidate ranking/content stays compatible
- use the same bounded index for initial-letter prefix fallback instead of scanning all initial keys
- precompute association keys by length instead of sorting them after every committed Chinese context
- add a 10,000-entry synthetic regression proving a 120-key match inspects at most 121 keys, plus ordering and absent-prefix tests

## User impact
This removes a deterministic O(full phrase table) operation from the candidate path that runs on ordinary key input. It is one of the concrete hot paths behind the real-device “not following the finger” feedback; the separate ownership cleanup in #28 remains follow-up work.

Closes #30