### PR TITLE
Disable handwriting entry until a recognizer is configured

### DIFF
--- a/app/src/main/java/llc/slacker/openime/HandwritingProvider.kt
+++ b/app/src/main/java/llc/slacker/openime/HandwritingProvider.kt
@@ -11,6 +11,10 @@ data class StrokePoint(val x: Float, val y: Float, val timestamp: Long, val pres
 data class Stroke(val points: List<StrokePoint>)
 
 interface HandwritingProvider {
+    /** Capability used by production UI before exposing the handwriting entry. */
+    val isAvailable: Boolean
+        get() = true
+
     fun recognize(strokes: List<Stroke>): HandwritingResult
 }
 
@@ -20,7 +24,13 @@ sealed class HandwritingResult {
     data class Error(val message: String) : HandwritingResult()
 }
 
+internal object HandwritingFeaturePolicy {
+    fun entryEnabled(provider: HandwritingProvider): Boolean = provider.isAvailable
+}
+
 object UnavailableHandwritingProvider : HandwritingProvider {
+    override val isAvailable: Boolean = false
+
     override fun recognize(strokes: List<Stroke>): HandwritingResult =
         HandwritingResult.NotConfigured
 }

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -111,6 +111,7 @@ class ImeKeyboardViewV2 private constructor(
     private fun syncProductionKeyPresentation() {
         normalizeSpaceRowGeometry()
         syncEnterKeyPresentation()
+        syncHandwritingCapability()
     }
 
     /**
@@ -172,6 +173,36 @@ class ImeKeyboardViewV2 private constructor(
                     view.setMainText(label)
                     view.contentDescription = label
                 }
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) visit(view.getChildAt(index))
+            }
+        }
+        visit(this)
+    }
+
+    /** Do not expose a dead handwriting flow while production has no recognizer. */
+    private fun syncHandwritingCapability() {
+        if (HandwritingFeaturePolicy.entryEnabled(UnavailableHandwritingProvider)) return
+
+        fun markUnavailableLabel(view: View) {
+            if (view is TextView && view.text.toString() == "手写输入") {
+                view.text = "手写输入·未配置"
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) markUnavailableLabel(view.getChildAt(index))
+            }
+        }
+
+        fun visit(view: View) {
+            if (view.contentDescription?.toString() == "手写输入") {
+                view.isEnabled = false
+                view.isClickable = false
+                view.isLongClickable = false
+                view.alpha = 0.38f
+                view.contentDescription = "手写输入（未配置）"
+                markUnavailableLabel(view)
+                return
             }
             if (view is ViewGroup) {
                 for (index in 0 until view.childCount) visit(view.getChildAt(index))

--- a/app/src/test/java/llc/slacker/openime/HandwritingFeaturePolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/HandwritingFeaturePolicyTest.kt
@@ -1,0 +1,23 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HandwritingFeaturePolicyTest {
+    @Test
+    fun unavailableProviderDisablesProductionEntry() {
+        assertFalse(HandwritingFeaturePolicy.entryEnabled(UnavailableHandwritingProvider))
+        assertTrue(UnavailableHandwritingProvider.recognize(emptyList()) is HandwritingResult.NotConfigured)
+    }
+
+    @Test
+    fun configuredProviderEnablesProductionEntry() {
+        val provider = object : HandwritingProvider {
+            override fun recognize(strokes: List<Stroke>): HandwritingResult =
+                HandwritingResult.Success(listOf("你"))
+        }
+
+        assertTrue(HandwritingFeaturePolicy.entryEnabled(provider))
+    }
+}


### PR DESCRIPTION
## Summary
- expose an explicit `HandwritingProvider.isAvailable` capability; real providers default to available while the production `UnavailableHandwritingProvider` reports false
- disable the production tools-panel handwriting card when the provider is unavailable, remove click/long-click behavior, dim it, and relabel it as `手写输入·未配置`
- keep the legacy handwriting panel/result behavior unchanged so a future configured provider can re-enable the entry without fake candidates
- add host coverage for unavailable and configured providers

## Dependency
This branch is stacked on #74 because the production capability filter lives in `ImeKeyboardViewV2`. Merge #74 first; after that this PR reduces to the three #39 files/changes.

Closes #39