### PR TITLE
Make clear-all require full editor capability

### DIFF
--- a/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
+++ b/app/src/main/java/llc/slacker/openime/InputConnectionGateway.kt
@@ -129,32 +129,66 @@ class InputConnectionGateway(
         }
     }
 
-    /** Clear the current editor text around the cursor, including a selection. */
+    /**
+     * Clear the complete editor document in one batch operation.
+     *
+     * The editor-owned select-all action is authoritative and handles documents
+     * far larger than any surrounding-text query. If that capability is absent,
+     * manual selection is used only when ExtractedText explicitly represents the
+     * complete document. A bounded/local window is never partially deleted while
+     * returning success: callers receive false instead and can present an
+     * unsupported-capability state.
+     */
     fun clearAllText(): Boolean {
         if (isPassword()) return false
         val ic = connection() ?: return false
         ic.beginBatchEdit()
         return try {
-            // Remove the active pre-edit instead of finishing (committing) it.
-            // Query surrounding text only afterwards so delete counts cannot
-            // include a stale composing span that an editor may resurrect.
+            // Remove active pre-edit rather than committing it before selecting.
             ic.setComposingText("", 1)
             ic.finishComposingText()
-            val before = ic.getTextBeforeCursor(100_000, 0)?.toString().orEmpty()
-            val after = ic.getTextAfterCursor(100_000, 0)?.toString().orEmpty()
-            val selected = ic.getSelectedText(0)?.toString().orEmpty()
-            if (selected.isNotEmpty()) ic.commitText("", 1)
-            val beforeCount = before.codePointCount(0, before.length)
-            val afterCount = after.codePointCount(0, after.length)
-            if (beforeCount > 0 || afterCount > 0) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    ic.deleteSurroundingTextInCodePoints(beforeCount, afterCount)
-                } else {
-                    ic.deleteSurroundingText(before.length, after.length)
+
+            if (runCatching { ic.performContextMenuAction(android.R.id.selectAll) }.getOrDefault(false)) {
+                val selected = runCatching { ic.getSelectedText(0)?.toString().orEmpty() }
+                    .getOrDefault("")
+                if (selected.isNotEmpty()) {
+                    val cleared = runCatching { ic.commitText("", 1) }.getOrDefault(false)
+                    ic.finishComposingText()
+                    return cleared
                 }
+
+                // Empty selection can mean either an empty document or an editor
+                // that claimed select-all without exposing/creating a selection.
+                // Only the complete extracted state can distinguish those safely.
+                val selectedWindow = extractedWindow(ic)
+                if (selectedWindow?.isCompleteDocument == true) {
+                    if (selectedWindow.text.isEmpty()) {
+                        ic.finishComposingText()
+                        return true
+                    }
+                    val fullSelection = selectedWindow.selectionStartAbsolute == 0 &&
+                        selectedWindow.selectionEndAbsolute == selectedWindow.text.length
+                    if (fullSelection) {
+                        val cleared = runCatching { ic.commitText("", 1) }.getOrDefault(false)
+                        ic.finishComposingText()
+                        return cleared
+                    }
+                }
+                return false
             }
+
+            val window = extractedWindow(ic) ?: return false
+            if (!window.isCompleteDocument) return false
+            if (window.text.isEmpty()) {
+                ic.finishComposingText()
+                return true
+            }
+            if (!runCatching { ic.setSelection(0, window.text.length) }.getOrDefault(false)) {
+                return false
+            }
+            val cleared = runCatching { ic.commitText("", 1) }.getOrDefault(false)
             ic.finishComposingText()
-            true
+            cleared
         } finally {
             ic.endBatchEdit()
         }
@@ -178,7 +212,7 @@ class InputConnectionGateway(
         val ic = connection() ?: return
         if (runCatching { ic.performContextMenuAction(android.R.id.selectAll) }.getOrDefault(false)) return
         val window = extractedWindow(ic) ?: return
-        if (window.windowStart == 0) {
+        if (window.isCompleteDocument) {
             ic.setSelection(0, window.text.length)
         }
     }
@@ -231,12 +265,12 @@ class InputConnectionGateway(
         null -> currentSelectionStart()
     }
 
-    /** Returns -1 when the available extracted text does not begin at document offset 0. */
+    /** Returns -1 unless ExtractedText explicitly represents the complete document. */
     fun currentTextLength(): Int {
         if (isPassword()) return -1
         val ic = connection() ?: return -1
         val window = extractedWindow(ic) ?: return -1
-        return if (window.windowStart == 0) window.text.length else -1
+        return if (window.isCompleteDocument) window.text.length else -1
     }
 
     fun cursorSnapshot(maxChars: Int = 8_192): CursorSnapshot? {
@@ -350,6 +384,9 @@ class InputConnectionGateway(
             windowStart = windowStart,
             selectionStartAbsolute = windowStart + extracted.selectionStart,
             selectionEndAbsolute = windowStart + extracted.selectionEnd,
+            isCompleteDocument = windowStart == 0 &&
+                extracted.partialStartOffset < 0 &&
+                extracted.partialEndOffset < 0,
         )
     }
 
@@ -368,6 +405,7 @@ class InputConnectionGateway(
         val windowStart: Int,
         val selectionStartAbsolute: Int,
         val selectionEndAbsolute: Int,
+        val isCompleteDocument: Boolean,
     )
 
     private companion object {

--- a/app/src/test/java/llc/slacker/openime/InputConnectionGatewayTest.kt
+++ b/app/src/test/java/llc/slacker/openime/InputConnectionGatewayTest.kt
@@ -10,6 +10,7 @@ import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,6 +26,8 @@ class InputConnectionGatewayTest {
             selectionStart = 0
             selectionEnd = 0
             startOffset = 0
+            partialStartOffset = -1
+            partialEndOffset = -1
         },
         var contextMenuResult: Boolean = false,
     ) : InputConnection {
@@ -91,11 +94,15 @@ class InputConnectionGatewayTest {
         startOffset: Int,
         selectionStart: Int,
         selectionEnd: Int,
+        partialStartOffset: Int = -1,
+        partialEndOffset: Int = -1,
     ) = ExtractedText().apply {
         this.text = text
         this.startOffset = startOffset
         this.selectionStart = selectionStart
         this.selectionEnd = selectionEnd
+        this.partialStartOffset = partialStartOffset
+        this.partialEndOffset = partialEndOffset
     }
 
     @Test
@@ -216,11 +223,31 @@ class InputConnectionGatewayTest {
     }
 
     @Test
-    fun clearAllCancelsCompositionThenUsesOneBatchDelete() {
+    fun selectAllDoesNotTreatPartialWindowAsWholeDocument() {
         val fake = FakeInputConnection(
-            beforeText = "旧😀",
-            selectedText = "选中",
-            afterText = "文本",
+            extractedText = extracted(
+                text = "window",
+                startOffset = 0,
+                selectionStart = 0,
+                selectionEnd = 0,
+                partialStartOffset = 0,
+                partialEndOffset = 6,
+            ),
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        gateway.selectAll()
+
+        assertTrue(fake.events.contains("context:${android.R.id.selectAll}"))
+        assertTrue(fake.events.none { it.startsWith("selection:") })
+        assertEquals(-1, gateway.currentTextLength())
+    }
+
+    @Test
+    fun clearAllUsesEditorSelectAllThenSingleReplacement() {
+        val fake = FakeInputConnection(
+            selectedText = "旧😀选中文本",
+            contextMenuResult = true,
         )
         val gateway = InputConnectionGateway(null, { fake })
 
@@ -228,12 +255,64 @@ class InputConnectionGatewayTest {
 
         assertEquals("compose:", fake.events[0])
         assertEquals("finish", fake.events[1])
-        assertEquals(1, fake.events.count { it.startsWith("delete") })
-        assertTrue(
-            fake.events.any {
-                it == "deleteCodePoints:2:2" || it == "delete:3:2"
-            },
+        assertTrue(fake.events.contains("context:${android.R.id.selectAll}"))
+        assertEquals(1, fake.events.count { it == "commit:" })
+        assertTrue(fake.events.none { it.startsWith("delete") })
+    }
+
+    @Test
+    fun clearAllHandlesOver200kCharactersThroughEditorOwnedSelection() {
+        val fake = FakeInputConnection(
+            selectedText = "x".repeat(200_001),
+            contextMenuResult = true,
         )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        assertTrue(gateway.clearAllText())
+        assertEquals(1, fake.events.count { it == "commit:" })
+        assertTrue(fake.events.none { it.startsWith("delete") })
+    }
+
+    @Test
+    fun clearAllCanUseCompleteExtractedDocumentWithoutBoundedDelete() {
+        val document = "x".repeat(200_001)
+        val fake = FakeInputConnection(
+            contextMenuResult = false,
+            extractedText = extracted(
+                text = document,
+                startOffset = 0,
+                selectionStart = 100_000,
+                selectionEnd = 100_000,
+            ),
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        assertTrue(gateway.clearAllText())
+        assertTrue(fake.events.contains("selection:0:200001"))
+        assertEquals(1, fake.events.count { it == "commit:" })
+        assertTrue(fake.events.none { it.startsWith("delete") })
+    }
+
+    @Test
+    fun clearAllRefusesPartialWindowInsteadOfSilentlyDeletingNearbyText() {
+        val fake = FakeInputConnection(
+            beforeText = "a".repeat(100_000),
+            afterText = "b".repeat(100_000),
+            contextMenuResult = false,
+            extractedText = extracted(
+                text = "window",
+                startOffset = 0,
+                selectionStart = 3,
+                selectionEnd = 3,
+                partialStartOffset = 0,
+                partialEndOffset = 6,
+            ),
+        )
+        val gateway = InputConnectionGateway(null, { fake })
+
+        assertFalse(gateway.clearAllText())
+        assertTrue(fake.events.none { it.startsWith("delete") })
+        assertTrue(fake.events.none { it == "commit:" })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stop implementing “清空” as a bounded 100k-before/100k-after surrounding-text delete that can silently leave content in long documents
- prefer the editor-owned Select All action and replace the selected document once with an empty string
- use ExtractedText fallback only when it explicitly represents the complete document; partial/bounded windows now return false without deleting nearby text
- make `selectAll()` and `currentTextLength()` use the same full-document capability boundary
- add >200k-character regressions for editor-owned selection and complete ExtractedText, plus a partial-window refusal test

## User impact
The UI no longer claims a complete clear while silently deleting only a local slice of a long/custom editor. Unsupported editors fail safely instead of losing an arbitrary surrounding region.

Closes #35