### PR TITLE
Add 10k ownership stress and real frame-jank baselines

### DIFF
--- a/app/src/test/java/llc/slacker/openime/VoiceLifecycleOwnershipStressTest.kt
+++ b/app/src/test/java/llc/slacker/openime/VoiceLifecycleOwnershipStressTest.kt
@@ -1,0 +1,81 @@
+package llc.slacker.openime
+
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Deterministic high-frequency ownership races; no microphone or device is required. */
+class VoiceLifecycleOwnershipStressTest {
+
+    @After
+    fun tearDown() {
+        VoicePerformanceTrace.resetForTest()
+    }
+
+    @Test
+    fun tenThousandStartCancelStartTraceCyclesNeverCrossGenerations() {
+        val clock = AtomicLong(10_000L)
+        VoicePerformanceTrace.resetForTest(
+            clock = { clock.incrementAndGet() },
+            logger = {},
+        )
+
+        repeat(10_000) {
+            val stale = VoicePerformanceTrace.begin()
+            val current = VoicePerformanceTrace.begin()
+
+            VoicePerformanceTrace.markFirstPcm(stale)
+            VoicePerformanceTrace.markFirstPcm(current)
+            VoicePerformanceTrace.abandon(stale)
+            VoicePerformanceTrace.finish(stale, droppedPcmSamples = 99L, failed = true)
+
+            assertFalse(VoicePerformanceTrace.isActiveForTest(stale))
+            assertTrue(VoicePerformanceTrace.isActiveForTest(current))
+
+            VoicePerformanceTrace.finish(current, droppedPcmSamples = 0L, failed = true)
+            assertFalse(VoicePerformanceTrace.isActiveForTest(current))
+        }
+
+        assertTrue(VoicePerformanceTrace.activeGenerationsForTest().isEmpty())
+    }
+
+    @Test
+    fun tenThousandOverlappingRouteCyclesRestoreOnlyLatestOwner() {
+        val ownership = VoiceRouteOwnership<Int>()
+        var baselineVersion = 0
+        var restoredCount = 0
+
+        repeat(10_000) {
+            val first = ownership.acquire { ++baselineVersion }
+            val latest = ownership.acquire { error("overlap must reuse the first baseline") }
+
+            assertTrue(first.firstOwner)
+            assertFalse(latest.firstOwner)
+            assertFalse(ownership.release(first.owner) { restoredCount++ })
+            assertTrue(ownership.release(latest.owner) { restoredCount++ })
+        }
+
+        assertEquals(10_000, baselineVersion)
+        assertEquals(10_000, restoredCount)
+    }
+
+    @Test
+    fun pcmRingRemainsBoundedAcrossTenThousandCaptureChunks() {
+        val chunk = ShortArray(LocalVoiceAudioSpec.CHUNK_SAMPLES) { it.toShort() }
+        val ring = PcmRingBuffer(LocalVoiceAudioSpec.CHUNK_SAMPLES * 8)
+
+        repeat(10_000) {
+            ring.offer(chunk)
+            if (it % 3 == 0) ring.drain(LocalVoiceAudioSpec.CHUNK_SAMPLES)
+            assertTrue(ring.size <= LocalVoiceAudioSpec.CHUNK_SAMPLES * 8)
+        }
+
+        assertTrue(ring.droppedSamples > 0L)
+        ring.clear()
+        assertEquals(0, ring.size)
+        assertEquals(0L, ring.droppedSamples)
+    }
+}

--- a/scripts/perf_baseline.ps1
+++ b/scripts/perf_baseline.ps1
@@ -1,4 +1,8 @@
-﻿param([string]$Serial = '')
+﻿param(
+    [string]$Serial = '',
+    [int]$TransportSamples = 50,
+    [int]$FrameInteractions = 100
+)
 
 $ErrorActionPreference = 'Stop'
 $project = Split-Path $PSScriptRoot -Parent
@@ -27,7 +31,14 @@ function Push([string]$cmd) {
     Adb shell am broadcast -n $receiver -a $action --es cmd $cmd | Out-Null
 }
 
-function MeasureCommands([string]$cmd, [int]$count) {
+function Percentile([double[]]$sorted, [double]$fraction) {
+    if ($sorted.Count -eq 0) { return 0.0 }
+    $index = [Math]::Ceiling($sorted.Count * $fraction) - 1
+    $index = [Math]::Max(0, [Math]::Min($index, $sorted.Count - 1))
+    return [Math]::Round($sorted[$index], 2)
+}
+
+function MeasureTransport([string]$cmd, [int]$count) {
     $times = @()
     for ($i = 0; $i -lt $count; $i++) {
         $sw = [Diagnostics.Stopwatch]::StartNew()
@@ -35,15 +46,31 @@ function MeasureCommands([string]$cmd, [int]$count) {
         $sw.Stop()
         $times += $sw.Elapsed.TotalMilliseconds
     }
-    $sorted = $times | Sort-Object
-    $idx = [Math]::Ceiling($count * 0.95) - 1
+    [double[]]$sorted = $times | Sort-Object
     [PSCustomObject]@{
         Command = $cmd
         Samples = $count
-        P50 = [Math]::Round(($sorted[[Math]::Ceiling($count * 0.5) - 1]), 2)
-        P95 = [Math]::Round($sorted[[Math]::Min($idx, $count - 1)], 2)
-        Max = [Math]::Round(($sorted | Select-Object -Last 1), 2)
-        Mean = [Math]::Round(($times | Measure-Object -Average).Average, 2)
+        P50Ms = Percentile $sorted 0.50
+        P95Ms = Percentile $sorted 0.95
+        P99Ms = Percentile $sorted 0.99
+        MaxMs = [Math]::Round(($sorted | Select-Object -Last 1), 2)
+        MeanMs = [Math]::Round(($times | Measure-Object -Average).Average, 2)
+    }
+}
+
+function ReadFrameJank {
+    $gfx = Adb shell dumpsys gfxinfo $pkg | Out-String
+    $totalMatch = [regex]::Match($gfx, 'Total frames rendered:\s*(\d+)')
+    $jankMatch = [regex]::Match($gfx, 'Janky frames:\s*(\d+)\s*\(([\d\.,]+)%\)')
+    $total = if ($totalMatch.Success) { [int]$totalMatch.Groups[1].Value } else { -1 }
+    $janky = if ($jankMatch.Success) { [int]$jankMatch.Groups[1].Value } else { -1 }
+    $percentText = if ($jankMatch.Success) { $jankMatch.Groups[2].Value.Replace(',', '.') } else { '-1' }
+    $percent = [double]::Parse($percentText, [Globalization.CultureInfo]::InvariantCulture)
+    [PSCustomObject]@{
+        TotalFrames = $total
+        JankyFrames = $janky
+        JankyPercent = $percent
+        Source = 'adb shell dumpsys gfxinfo; actual app frame statistics, not adb round-trip timing'
     }
 }
 
@@ -65,15 +92,31 @@ if ($node.bounds -match '\[(\d+),(\d+)\]\[(\d+),(\d+)\]') {
 }
 WaitIme
 
-$mode = MeasureCommands 'tap:key:mode' 20
-$state = MeasureCommands 'state' 20
+# These are transport baselines only. Do not call them key latency: each sample
+# includes host scheduling, adb, ActivityManager broadcast delivery and receiver work.
+$modeTransport = MeasureTransport 'tap:key:mode' $TransportSamples
+$stateTransport = MeasureTransport 'state' $TransportSamples
+
+# Reset framework frame counters, exercise production UI, then read actual app
+# frame statistics. This complements (but does not replace) an on-device
+# key-down -> candidate timestamp trace for real-device P50/P95/P99.
+Adb shell dumpsys gfxinfo $pkg reset | Out-Null
+for ($i = 0; $i -lt $FrameInteractions; $i++) {
+    Push 'tap:key:mode'
+}
+Start-Sleep -Milliseconds 500
+$frameJank = ReadFrameJank
+
 $result = [PSCustomObject]@{
     Device = $Serial
     MeasuredAt = (Get-Date -Format o)
-    Note = 'Host->adb broadcast round trip; not frame/Jank measurement'
-    ModeSwitch = $mode
-    StateQuery = $state
+    TransportNote = 'P50/P95/P99 below are host->adb broadcast round trips; they are deliberately not labeled key latency.'
+    ModeSwitchTransport = $modeTransport
+    StateQueryTransport = $stateTransport
+    FrameInteractions = $FrameInteractions
+    FrameJank = $frameJank
+    RemainingRealDeviceAcceptance = 'Record on-device key-down -> visual/composition/first-candidate P50/P95/P99 on representative hardware.'
 }
 $json = Join-Path $outDir 'baseline.json'
-$result | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $json -Encoding utf8
+$result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $json -Encoding utf8
 Get-Content -LiteralPath $json -Raw

--- a/scripts/stress_baseline.ps1
+++ b/scripts/stress_baseline.ps1
@@ -1,4 +1,8 @@
-﻿param([string]$Serial = '')
+﻿param(
+    [string]$Serial = '',
+    [int]$Iterations = 2500,
+    [int]$CommandDelayMs = 10
+)
 
 $ErrorActionPreference = 'Stop'
 $project = Split-Path $PSScriptRoot -Parent
@@ -25,15 +29,30 @@ function WaitIme {
 
 function Push([string]$cmd) {
     Adb shell am broadcast -n $receiver -a $action --es cmd $cmd | Out-Null
-    Start-Sleep -Milliseconds 60
+    if ($CommandDelayMs -gt 0) { Start-Sleep -Milliseconds $CommandDelayMs }
 }
 
+function ReadPid {
+    return (Adb shell pidof $pkg | Out-String).Trim()
+}
+
+function ReadPssKb {
+    $memory = Adb shell dumpsys meminfo $pkg | Out-String
+    $match = [regex]::Match($memory, 'TOTAL PSS:\s*(\d+)')
+    if (-not $match.Success) { return -1 }
+    return [int]$match.Groups[1].Value
+}
+
+if ($Iterations -lt 2500) {
+    throw 'Iterations must be at least 2500 so the default 4-command loop executes >=10,000 commands'
+}
 if (-not (Test-Path -LiteralPath $apk)) { throw 'missing APK' }
+
 Adb install -r $apk | Out-Null
 Adb shell settings put --user 0 secure default_input_method "$pkg/.LocalVoiceImeService"
 Adb shell settings put --user 0 secure show_ime_with_hard_keyboard 1
-Adb shell ime enable --user 0 "$pkg/.LocalVoiceImeService"
-Adb shell ime set --user 0 "$pkg/.LocalVoiceImeService"
+Adb shell ime enable --user 0 "$pkg/.LocalVoiceImeService" | Out-Null
+Adb shell ime set --user 0 "$pkg/.LocalVoiceImeService" | Out-Null
 Adb shell am force-stop $pkg | Out-Null
 Start-Sleep -Seconds 1
 Adb shell am start -n "$pkg/.LifecycleTestActivity" | Out-Null
@@ -48,24 +67,60 @@ if ($node.bounds -match '\[(\d+),(\d+)\]\[(\d+),(\d+)\]') {
 }
 WaitIme
 
+$initialPid = ReadPid
+if ([string]::IsNullOrWhiteSpace($initialPid)) { throw 'IME process is not alive before stress run' }
+$initialPssKb = ReadPssKb
+Adb logcat -c | Out-Null
+
 $start = Get-Date
-for ($i = 0; $i -lt 500; $i++) {
-    Push 'tap:key:mode'
-    Push 'tap:Emoji'
-    Push 'tap:key-panel-back'
+$commands = 0
+$processRestarted = $false
+for ($i = 0; $i -lt $Iterations; $i++) {
+    # Exercise candidate/composition work, deletion, and two mode transitions.
+    Push 'tap:key:n'; $commands++
+    Push 'tap:key-backspace'; $commands++
+    Push 'tap:key:mode'; $commands++
+    Push 'tap:key:mode'; $commands++
+
+    if (($i + 1) % 250 -eq 0) {
+        $pidNow = ReadPid
+        if ([string]::IsNullOrWhiteSpace($pidNow)) {
+            throw "IME process died after $commands commands"
+        }
+        if ($pidNow -ne $initialPid) { $processRestarted = $true }
+    }
 }
 $elapsed = ((Get-Date) - $start).TotalSeconds
-$pidValue = (Adb shell pidof $pkg | Out-String).Trim()
-$memory = Adb shell dumpsys meminfo $pkg | Out-String
-$fatal = Adb logcat -d -t 2000 | Out-String
-$json = Join-Path $outDir 'stress-500.json'
-[PSCustomObject]@{
+
+$finalPid = ReadPid
+$finalPssKb = ReadPssKb
+$logcat = Adb logcat -d -v threadtime | Out-String
+$packageFatalPattern = "FATAL EXCEPTION|ANR in $([regex]::Escape($pkg))|Process: $([regex]::Escape($pkg))"
+$fatalAnr = $logcat -match $packageFatalPattern
+
+$result = [PSCustomObject]@{
     Device = $Serial
-    Iterations = 500
-    Commands = 1500
+    MeasuredAt = (Get-Date -Format o)
+    Iterations = $Iterations
+    Commands = $commands
+    CommandMix = 'key:n + backspace + mode + mode'
+    CommandDelayMs = $CommandDelayMs
     ElapsedSeconds = [Math]::Round($elapsed, 2)
-    Pid = $pidValue
-    PssKb = ([regex]::Match($memory, 'TOTAL PSS:\s*(\d+)').Groups[1].Value)
-    FatalAnr = ($fatal -match 'FATAL|ANR|AndroidRuntime')
-} | ConvertTo-Json | Set-Content -LiteralPath $json -Encoding utf8
+    InitialPid = $initialPid
+    FinalPid = $finalPid
+    ProcessRestarted = $processRestarted
+    InitialPssKb = $initialPssKb
+    FinalPssKb = $finalPssKb
+    PssDeltaKb = if ($initialPssKb -ge 0 -and $finalPssKb -ge 0) { $finalPssKb - $initialPssKb } else { -1 }
+    FatalOrAnr = $fatalAnr
+    Acceptance = if (-not $fatalAnr -and -not [string]::IsNullOrWhiteSpace($finalPid) -and -not $processRestarted) { 'PASS' } else { 'FAIL' }
+}
+
+$json = Join-Path $outDir 'stress-10k.json'
+$result | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $json -Encoding utf8
 Get-Content -LiteralPath $json -Raw
+
+if ($commands -lt 10000) { throw "stress command count below acceptance floor: $commands" }
+if ([string]::IsNullOrWhiteSpace($finalPid)) { throw 'IME process not alive after stress run' }
+if ($processRestarted) { throw 'IME process restarted during stress run' }
+if ($fatalAnr) { throw 'FATAL/ANR evidence detected for openIME during stress run' }


### PR DESCRIPTION
## Summary
- add deterministic 10,000-cycle stress coverage for voice trace generation, audio-route ownership, and bounded PCM buffering
- raise the device stress script from 1,500 commands to at least 10,000 commands and fail on process death/restart or openIME FATAL/ANR evidence
- record initial/final PSS and memory delta during the stress run
- separate host→adb transport P50/P95/P99 from actual input latency so the report no longer mislabels transport RTT as key latency
- add `dumpsys gfxinfo` frame/jank statistics after repeated production UI interactions

## Acceptance status
This advances the automated T9/T10 coverage but intentionally does **not** close #38. The issue still requires representative real-device key-down → visual/composition/first-candidate P50/P95/P99 evidence and at least one executed real-device stress run before it can be marked PASS.

Related to #38