### PR TITLE
Make the service own candidate resolution

### DIFF
--- a/app/src/debug/java/llc/slacker/openime/DebugKeyboardActivity.kt
+++ b/app/src/debug/java/llc/slacker/openime/DebugKeyboardActivity.kt
@@ -11,14 +11,18 @@ import android.widget.LinearLayout
 import android.widget.TextView
 
 /** Debug-only keyboard renderer used by instrumented and visual tests. */
-class DebugKeyboardActivity : Activity(), ImeKeyboardView.Listener {
+class DebugKeyboardActivity : Activity(), ImeKeyboardView.Listener, CandidateResolver {
 
     private lateinit var input: TextView
     private lateinit var status: TextView
     private lateinit var keyboard: ImeKeyboardView
+    private val candidatePipeline by lazy {
+        CandidatePipeline(CandidateEngine(PinyinLexicon.load(this)))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        UserPhraseRepository.configure(this)
 
         val density = resources.displayMetrics.density
         fun dp(value: Int): Int = (value * density).toInt()
@@ -66,6 +70,24 @@ class DebugKeyboardActivity : Activity(), ImeKeyboardView.Listener {
         )
         setContentView(root)
     }
+
+    override fun candidatesFor(
+        mode: KeyboardMode,
+        composition: String,
+        fuzzy: Boolean,
+    ): List<String> = candidatePipeline.candidatesFor(mode, composition, fuzzy)
+
+    override fun resolveNineKey(
+        digits: String,
+        segmentPrefix: String,
+        preferredSuffix: String?,
+        fuzzy: Boolean,
+    ): CandidatePipeline.NineKeyResolution = candidatePipeline.resolveNineKey(
+        digits = digits,
+        segmentPrefix = segmentPrefix,
+        preferredSuffix = preferredSuffix,
+        fuzzy = fuzzy,
+    )
 
     override fun onModeChanged(mode: KeyboardMode) {
         status.text = "mode=$mode"

--- a/app/src/main/java/llc/slacker/openime/CandidatePipeline.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidatePipeline.kt
@@ -1,0 +1,132 @@
+package llc.slacker.openime
+
+/** Capability exposed by the service to a thin keyboard renderer. */
+interface CandidateResolver {
+    fun candidatesFor(
+        mode: KeyboardMode,
+        composition: String,
+        fuzzy: Boolean,
+    ): List<String>
+
+    fun resolveNineKey(
+        digits: String,
+        segmentPrefix: String,
+        preferredSuffix: String?,
+        fuzzy: Boolean,
+    ): CandidatePipeline.NineKeyResolution
+}
+
+/**
+ * Service-owned local candidate pipeline.
+ *
+ * The View may keep transient key/composition buffers, but it must not own a
+ * CandidateEngine or candidate ordering rules. Keeping the engine behind this
+ * boundary makes the service the single authoritative owner for 26-key,
+ * English, T9, 9-key, and association fallback semantics.
+ */
+class CandidatePipeline(
+    private val engine: CandidateEngine,
+) : CandidateResolver {
+    data class NineKeyResolution(
+        val preview: String,
+        val pinyinPaths: List<String>,
+        val candidates: List<String>,
+    )
+
+    override fun candidatesFor(
+        mode: KeyboardMode,
+        composition: String,
+        fuzzy: Boolean,
+    ): List<String> = when (mode) {
+        KeyboardMode.PINYIN_26 -> engine.getCandidates(composition, fuzzy)
+        KeyboardMode.ENGLISH_26 -> engine.getEnglishCompletions(composition)
+        KeyboardMode.PINYIN_9 -> if (composition.length <= 32) {
+            engine.getCandidates(composition, fuzzy)
+        } else {
+            emptyList()
+        }
+        KeyboardMode.ENGLISH_T9 -> engine.getT9EnglishCandidates(composition)
+        KeyboardMode.DIGITS -> emptyList()
+    }
+
+    fun associationsFor(context: String): List<String> = engine.getAssociations(context)
+
+    override fun resolveNineKey(
+        digits: String,
+        segmentPrefix: String,
+        preferredSuffix: String?,
+        fuzzy: Boolean,
+    ): NineKeyResolution {
+        val boundedDigits = digits
+            .filter { it in '2'..'9' }
+            .take(CandidateEngine.MAX_NINE_KEY_DIGITS)
+        if (boundedDigits.isEmpty()) {
+            return NineKeyResolution(
+                preview = segmentPrefix,
+                pinyinPaths = listOf(segmentPrefix).filter { it.isNotBlank() },
+                candidates = emptyList(),
+            )
+        }
+
+        val result = engine.get9KeyCandidates(boundedDigits)
+        val fallbackPath = boundedDigits.mapNotNull { digit ->
+            ImeData.keypad9Map[digit.toString()]
+                ?.firstOrNull { it.length == 1 && it[0] in 'a'..'z' }
+        }.joinToString("")
+        val stableSuffix = preferredSuffix
+            ?.lowercase()
+            ?.takeIf { suffix -> nineKeyDigitsFor(suffix) == boundedDigits }
+        val pinyinPaths = (listOfNotNull(stableSuffix) + result.pinyins)
+            .asSequence()
+            .filter { it.isNotBlank() }
+            .map { segmentPrefix + it }
+            .distinct()
+            .take(8)
+            .toList()
+            .ifEmpty {
+                listOf(segmentPrefix + fallbackPath).filter { it.isNotBlank() }
+            }
+        val preview = pinyinPaths.firstOrNull().orEmpty()
+        val localCandidates = candidatesFor(
+            mode = KeyboardMode.PINYIN_9,
+            composition = preview,
+            fuzzy = fuzzy,
+        )
+        val candidates = (
+            if (segmentPrefix.isEmpty()) {
+                result.candidates + localCandidates
+            } else {
+                localCandidates + result.candidates
+            }
+            )
+            .filter { it.isNotEmpty() && it.none(Char::isDigit) }
+            .distinct()
+            .take(96)
+
+        return NineKeyResolution(
+            preview = preview,
+            pinyinPaths = pinyinPaths,
+            candidates = candidates,
+        )
+    }
+
+    private fun nineKeyDigitsFor(pinyin: String): String? {
+        val digits = StringBuilder(pinyin.length)
+        pinyin.forEach { ch ->
+            digits.append(
+                when (ch) {
+                    in 'a'..'c' -> '2'
+                    in 'd'..'f' -> '3'
+                    in 'g'..'i' -> '4'
+                    in 'j'..'l' -> '5'
+                    in 'm'..'o' -> '6'
+                    in 'p'..'s' -> '7'
+                    in 't'..'v' -> '8'
+                    in 'w'..'z' -> '9'
+                    else -> return null
+                },
+            )
+        }
+        return digits.toString()
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardView.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardView.kt
@@ -117,9 +117,7 @@ open class ImeKeyboardView(
     private var backspaceClearUiAction: ((Boolean) -> Unit)? = null
     private var backspaceRepeatStartAction: Runnable? = null
 
-    private val engine = CandidateEngine(PinyinLexicon.load(context).also {
-        UserPhraseRepository.configure(context)
-    })
+    private val candidateProvider = context as? CandidateResolver
     private var theme = ImeTheme.IOS
     private var appearance = ImeAppearance.SYSTEM
     private var mode = KeyboardMode.PINYIN_26
@@ -1065,7 +1063,7 @@ open class ImeKeyboardView(
                     filterChip(f, f == t9Filter) {
                         t9Filter = f
                         renderModeBody()
-                        publishComposition(lastT9Digits, engine.getT9EnglishCandidates(lastT9Digits))
+                        publishComposition(lastT9Digits, candidatesForComposition(lastT9Digits))
                     },
                     LinearLayout.LayoutParams(
                         0,
@@ -2894,16 +2892,20 @@ open class ImeKeyboardView(
         if (!insertIntoInlineEditor(text)) listener.onCharacter(text)
     }
 
+    private fun requireCandidateProvider(): CandidateResolver = requireNotNull(candidateProvider) {
+        "Candidate-producing keyboard modes require a CandidateResolver host"
+    }
+
     private fun onKeyTapped(base: String) {
         if (insertIntoInlineEditor(base)) return
         clearAssociationCandidates()
         if (mode == KeyboardMode.PINYIN_26) {
             val (py, selection) = replaceCompositionSelection(base)
-            publishComposition(py, engine.getCandidates(py, fuzzyEnabled), selection)
+            publishComposition(py, candidatesForComposition(py), selection)
         } else if (mode == KeyboardMode.ENGLISH_26) {
             val ch = if (shiftState != ShiftState.LOWERCASE) base.uppercase() else base
             val (py, selection) = replaceCompositionSelection(ch)
-            publishComposition(py, engine.getEnglishCompletions(py), selection)
+            publishComposition(py, candidatesForComposition(py), selection)
             if (shiftState == ShiftState.SHIFT_ONCE) {
                 shiftState = ShiftState.LOWERCASE
                 listener.onShiftStateChanged(shiftState)
@@ -2931,7 +2933,7 @@ open class ImeKeyboardView(
         if (mode == KeyboardMode.ENGLISH_T9) {
             val (digits, selection) = replaceCompositionSelection(num)
             lastT9Digits = digits
-            publishComposition(digits, engine.getT9EnglishCandidates(digits), selection)
+            publishComposition(digits, candidatesForComposition(digits), selection)
         } else if (mode == KeyboardMode.PINYIN_9) {
             if (lastNineDigits.isEmpty()) {
                 lastNineSegmentPrefix = composition.text
@@ -2950,40 +2952,15 @@ open class ImeKeyboardView(
         digits: String,
         preferredSuffix: String? = null,
     ) {
-        val result = engine.get9KeyCandidates(digits)
-        val fallbackPath = digits.mapNotNull { digit ->
-            ImeData.keypad9Map[digit.toString()]
-                ?.firstOrNull { it.length == 1 && it[0] in 'a'..'z' }
-        }.joinToString("")
-        val stableSuffix = preferredSuffix
-            ?.lowercase()
-            ?.takeIf { suffix -> nineKeyDigitsFor(suffix) == digits }
-        val pinyinPaths = (listOfNotNull(stableSuffix) + result.pinyins)
-            .asSequence()
-            .filter { it.isNotBlank() }
-            .map { lastNineSegmentPrefix + it }
-            .distinct()
-            .take(8)
-            .toList()
-            .ifEmpty {
-                listOf(lastNineSegmentPrefix + fallbackPath).filter { it.isNotBlank() }
-            }
-        val preview = pinyinPaths.firstOrNull().orEmpty()
-        val localCandidates = if (preview.length <= 32) {
-            engine.getCandidates(preview, fuzzyEnabled)
-        } else {
-            emptyList()
-        }
-        val candidates = (
-            if (lastNineSegmentPrefix.isEmpty()) {
-                result.candidates + localCandidates
-            } else {
-                localCandidates + result.candidates
-            }
-            )
-            .filter { it.isNotEmpty() && it.none(Char::isDigit) }
-            .distinct()
-            .take(96)
+        val resolution = requireCandidateProvider().resolveNineKey(
+            digits = digits,
+            segmentPrefix = lastNineSegmentPrefix,
+            preferredSuffix = preferredSuffix,
+            fuzzy = fuzzyEnabled,
+        )
+        val preview = resolution.preview
+        val pinyinPaths = resolution.pinyinPaths
+        val candidates = resolution.candidates
         lastNineDigits = digits
         lastNinePinyinPaths = pinyinPaths
         lastNineCandidates = candidates
@@ -3000,26 +2977,6 @@ open class ImeKeyboardView(
             candidates = candidates,
         )
         applyCandidateTheme()
-    }
-
-    private fun nineKeyDigitsFor(pinyin: String): String? {
-        val digits = StringBuilder(pinyin.length)
-        pinyin.forEach { ch ->
-            digits.append(
-                when (ch) {
-                    in 'a'..'c' -> '2'
-                    in 'd'..'f' -> '3'
-                    in 'g'..'i' -> '4'
-                    in 'j'..'l' -> '5'
-                    in 'm'..'o' -> '6'
-                    in 'p'..'s' -> '7'
-                    in 't'..'v' -> '8'
-                    in 'w'..'z' -> '9'
-                    else -> return null
-                },
-            )
-        }
-        return digits.toString()
     }
 
     /** Insert an editable syllable boundary without committing the text. */
@@ -3079,12 +3036,9 @@ open class ImeKeyboardView(
         applyCandidateTheme()
     }
 
-    private fun candidatesForComposition(text: String): List<String> = when (mode) {
-        KeyboardMode.PINYIN_26 -> engine.getCandidates(text, fuzzyEnabled)
-        KeyboardMode.ENGLISH_26 -> engine.getEnglishCompletions(text)
-        KeyboardMode.PINYIN_9 -> engine.getCandidates(text, fuzzyEnabled)
-        KeyboardMode.ENGLISH_T9 -> engine.getT9EnglishCandidates(text)
-        KeyboardMode.DIGITS -> emptyList()
+    private fun candidatesForComposition(text: String): List<String> {
+        if (text.isEmpty()) return emptyList()
+        return requireCandidateProvider().candidatesFor(mode, text, fuzzyEnabled)
     }
 
     private fun replaceCompositionSelection(insert: String): Pair<String, Int> {
@@ -3784,8 +3738,8 @@ open class ImeKeyboardView(
         weight,
     ).apply {
         marginStart = dp(gapDp)
-            marginEnd = dp(gapDp)
-        }
+        marginEnd = dp(gapDp)
+    }
     private fun gridCellParams(
         heightDp: Int,
         columns: Int,

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicLong
  * Native system IME service. The view is a thin native renderer; all candidate
  * state, editor side effects and privacy rules live here.
  */
-class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
+class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, CandidateResolver {
 
     private data class CandidateDiagnostics(
         val learnedCount: Int = 0,
@@ -47,7 +47,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
 
     private var keyboardView: ImeKeyboardView? = null
     private lateinit var gateway: InputConnectionGateway
-    private lateinit var engine: CandidateEngine
+    private lateinit var candidatePipeline: CandidatePipeline
     private lateinit var rime: RimeEngine
     private lateinit var voiceLifecycle: VoiceModelLifecycleManager
     private var state = ImeState()
@@ -133,7 +133,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         UserPhraseRepository.configure(this)
         VoiceCorrectionRepository.configure(this)
         voiceLifecycle = VoiceModelLifecycleManager(this)
-        engine = CandidateEngine(PinyinLexicon.load(this))
+        candidatePipeline = CandidatePipeline(CandidateEngine(PinyinLexicon.load(this)))
         rime = RimeEngine(this).also { it.start() }
         gateway = InputConnectionGateway(
             context = this,
@@ -153,6 +153,24 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             skinPrimaryColor = ImeSettingsRepository.loadSkinColor(this),
         )
     }
+
+    override fun candidatesFor(
+        mode: KeyboardMode,
+        composition: String,
+        fuzzy: Boolean,
+    ): List<String> = candidatePipeline.candidatesFor(mode, composition, fuzzy)
+
+    override fun resolveNineKey(
+        digits: String,
+        segmentPrefix: String,
+        preferredSuffix: String?,
+        fuzzy: Boolean,
+    ): CandidatePipeline.NineKeyResolution = candidatePipeline.resolveNineKey(
+        digits = digits,
+        segmentPrefix = segmentPrefix,
+        preferredSuffix = preferredSuffix,
+        fuzzy = fuzzy,
+    )
 
     override fun onCreateInputView(): View {
         keyboardView = ImeKeyboardViewV2(this, this)
@@ -690,9 +708,9 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
             return
         }
         val modeAtRequest = state.keyboardMode
-        // The view has already produced the bounded local result for this
-        // key event. Reusing it avoids running the same dictionary work a
-        // second time on the IME main thread during rapid 9-key input.
+        // The service-owned pipeline has already produced the bounded local
+        // result for this key event. Reuse that immutable list while the native
+        // Rime query runs instead of performing dictionary work twice.
         val fallback = candidates.ifEmpty {
             fallbackCandidatesFor(composition, modeAtRequest)
         }
@@ -848,18 +866,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         commitFirstCandidate()
     }
 
-    private fun fallbackCandidatesFor(composition: String, mode: KeyboardMode): List<String> = when (mode) {
-        KeyboardMode.ENGLISH_26 -> engine.getEnglishCompletions(composition)
-        KeyboardMode.PINYIN_26,
-        -> engine.getCandidates(composition, state.fuzzyPinyinEnabled)
-        KeyboardMode.PINYIN_9 -> if (composition.length <= 32) {
-            engine.getCandidates(composition, state.fuzzyPinyinEnabled)
-        } else {
-            emptyList()
-        }
-        KeyboardMode.ENGLISH_T9 -> engine.getT9EnglishCandidates(composition)
-        else -> emptyList()
-    }
+    private fun fallbackCandidatesFor(composition: String, mode: KeyboardMode): List<String> =
+        candidatePipeline.candidatesFor(mode, composition, state.fuzzyPinyinEnabled)
 
     /** The extra learner is only a repeated-choice fallback while Rime is unavailable. */
     private fun immediateCandidates(composition: String, fallback: List<String>): List<String> {
@@ -1049,7 +1057,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener {
         lastComposition = ""
         state = state.copy(composition = "", candidates = emptyList())
         keyboardView?.renderState(state)
-        keyboardView?.setAssociationCandidates(engine.getAssociations(committed))
+        keyboardView?.setAssociationCandidates(candidatePipeline.associationsFor(committed))
     }
 
     private fun beginVoiceCorrection(original: String) {

--- a/app/src/test/java/llc/slacker/openime/CandidatePipelineTest.kt
+++ b/app/src/test/java/llc/slacker/openime/CandidatePipelineTest.kt
@@ -1,0 +1,77 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CandidatePipelineTest {
+    private val engine = CandidateEngine(
+        linkedMapOf(
+            "ni" to listOf("你", "呢"),
+            "hao" to listOf("好", "号"),
+            "nihao" to listOf("你好", "拟好"),
+        ),
+    )
+    private val pipeline = CandidatePipeline(engine)
+
+    @Test
+    fun ordinaryModesPreserveCandidateEngineSemantics() {
+        assertEquals(
+            engine.getCandidates("nihao", false),
+            pipeline.candidatesFor(KeyboardMode.PINYIN_26, "nihao", false),
+        )
+        assertEquals(
+            engine.getEnglishCompletions("hel"),
+            pipeline.candidatesFor(KeyboardMode.ENGLISH_26, "hel", false),
+        )
+        assertEquals(
+            engine.getT9EnglishCandidates("435"),
+            pipeline.candidatesFor(KeyboardMode.ENGLISH_T9, "435", false),
+        )
+        assertTrue(pipeline.candidatesFor(KeyboardMode.DIGITS, "123", false).isEmpty())
+    }
+
+    @Test
+    fun nineKeyResolutionOwnsPreviewPathsAndCandidateOrdering() {
+        val resolution = pipeline.resolveNineKey(
+            digits = "64426",
+            segmentPrefix = "",
+            preferredSuffix = "nihao",
+            fuzzy = false,
+        )
+
+        assertEquals("nihao", resolution.preview)
+        assertEquals("nihao", resolution.pinyinPaths.first())
+        assertTrue(resolution.candidates.isNotEmpty())
+        assertFalse(resolution.candidates.any { candidate -> candidate.any(Char::isDigit) })
+        assertEquals(resolution.candidates.distinct(), resolution.candidates)
+    }
+
+    @Test
+    fun segmentedNineKeyKeepsPrefixAheadOfRawDigitCandidates() {
+        val resolution = pipeline.resolveNineKey(
+            digits = "426",
+            segmentPrefix = "ni ",
+            preferredSuffix = "hao",
+            fuzzy = false,
+        )
+
+        assertEquals("ni hao", resolution.preview)
+        assertTrue(resolution.pinyinPaths.all { it.startsWith("ni ") })
+        assertTrue(resolution.candidates.none { it.any(Char::isDigit) })
+    }
+
+    @Test
+    fun nineKeyInputIsBoundedBeforeEngineResolution() {
+        val resolution = pipeline.resolveNineKey(
+            digits = "6".repeat(CandidateEngine.MAX_NINE_KEY_DIGITS + 20),
+            segmentPrefix = "",
+            preferredSuffix = null,
+            fuzzy = false,
+        )
+
+        assertTrue(resolution.pinyinPaths.size <= 8)
+        assertTrue(resolution.candidates.size <= 96)
+    }
+}


### PR DESCRIPTION
## Summary
- move local candidate ranking and 9-key resolution behind a Service-owned `CandidatePipeline`
- remove `CandidateEngine` ownership and 9-key ordering semantics from `ImeKeyboardView`
- route 26-key, English, T9, 9-key, and association fallbacks through the authoritative Service pipeline
- keep the debug renderer explicit by giving its test host a dedicated resolver

## Validation
- add deterministic `CandidatePipelineTest` coverage for mode routing and 9-key resolution/order
- preserve existing 26-key, 9-key, and English/T9 behavior while the native Rime pipeline remains authoritative for final candidates

Closes #28