### PR TITLE
Feed Rime selections into private voice personalization

### DIFF
--- a/app/src/main/java/llc/slacker/openime/PersonalizationRepository.kt
+++ b/app/src/main/java/llc/slacker/openime/PersonalizationRepository.kt
@@ -1,0 +1,135 @@
+package llc.slacker.openime
+
+import android.content.Context
+import android.view.inputmethod.EditorInfo
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Candidate-selection events used only to bias local ASR hotwords.
+ *
+ * This store is deliberately separate from candidate ranking. Rime userdb
+ * remains the authoritative learner for normal native candidate ordering, and
+ * UserPhraseRepository remains only the Rime-unavailable fallback learner.
+ */
+object PersonalizationRepository {
+    private const val PREFS = "personalization_events"
+    private const val KEY = "selected_terms"
+    private const val MAX_ENTRIES = 1_000
+
+    private data class Entry(
+        val text: String,
+        var count: Int,
+        var lastUsed: Long,
+    )
+
+    private val lock = Any()
+    private var preferences: android.content.SharedPreferences? = null
+    private val entries = LinkedHashMap<String, Entry>()
+
+    fun configure(context: Context) {
+        synchronized(lock) {
+            if (preferences != null) return
+            preferences = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            loadLocked()
+        }
+    }
+
+    fun record(text: String) {
+        val value = normalize(text)
+        if (value.isEmpty()) return
+        synchronized(lock) {
+            val current = entries[value]
+            if (current == null) {
+                entries[value] = Entry(value, count = 1, lastUsed = System.currentTimeMillis())
+            } else {
+                current.count = (current.count + 1).coerceAtMost(1_000_000)
+                current.lastUsed = System.currentTimeMillis()
+            }
+            trimLocked()
+            saveLocked()
+        }
+    }
+
+    /** Repeated explicit selections are eligible to bias local speech only. */
+    fun hotwords(
+        minimumFrequency: Int = 2,
+        limit: Int = 64,
+    ): List<String> {
+        val threshold = minimumFrequency.coerceAtLeast(1)
+        val boundedLimit = limit.coerceIn(0, 128)
+        if (boundedLimit == 0) return emptyList()
+        synchronized(lock) {
+            return entries.values
+                .asSequence()
+                .filter { it.count >= threshold }
+                .sortedWith(compareByDescending<Entry> { it.count }.thenByDescending { it.lastUsed })
+                .map { it.text }
+                .take(boundedLimit)
+                .toList()
+        }
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            entries.clear()
+            preferences?.edit()?.remove(KEY)?.apply()
+        }
+    }
+
+    private fun normalize(value: String): String {
+        val cleaned = value.trim().replace(Regex("\\s+"), " ")
+        if (cleaned.isEmpty() || cleaned.length > 128) return ""
+        return cleaned
+    }
+
+    private fun trimLocked() {
+        if (entries.size <= MAX_ENTRIES) return
+        entries.values
+            .sortedWith(compareBy<Entry> { it.count }.thenBy { it.lastUsed })
+            .take(entries.size - MAX_ENTRIES)
+            .forEach { entries.remove(it.text) }
+    }
+
+    private fun loadLocked() {
+        entries.clear()
+        val raw = preferences?.getString(KEY, null).orEmpty()
+        runCatching {
+            val array = JSONArray(raw)
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                val text = normalize(item.optString("text"))
+                if (text.isEmpty()) continue
+                entries[text] = Entry(
+                    text = text,
+                    count = item.optInt("count", 1).coerceAtLeast(1),
+                    lastUsed = item.optLong("lastUsed", 0L),
+                )
+            }
+            trimLocked()
+        }
+    }
+
+    private fun saveLocked() {
+        val target = preferences ?: return
+        val array = JSONArray()
+        entries.values.forEach { entry ->
+            array.put(
+                JSONObject()
+                    .put("text", entry.text)
+                    .put("count", entry.count)
+                    .put("lastUsed", entry.lastUsed),
+            )
+        }
+        target.edit().putString(KEY, array.toString()).apply()
+    }
+}
+
+/** Privacy gate captured at the editor event that produced a learning signal. */
+object PersonalizationPolicy {
+    fun allow(info: EditorInfo?): Boolean {
+        if (info == null) return false
+        if (EditorInfoAdapter.isPassword(EditorInfoAdapter.kind(info))) return false
+        return (info.imeOptions and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING) == 0
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -1,6 +1,7 @@
 package llc.slacker.openime
 
 import android.content.Context
+import android.inputmethodservice.InputMethodService
 import android.os.Build
 import android.util.Log
 import java.io.File
@@ -117,6 +118,10 @@ class RimeEngine(private val context: Context) {
     var errorMessage: String = ""
         private set
 
+    init {
+        PersonalizationRepository.configure(context)
+    }
+
     fun start() {
         if (isReady) return
         val generation = startupGate.begin() ?: return
@@ -204,7 +209,10 @@ class RimeEngine(private val context: Context) {
     fun selectCandidate(input: String, candidate: String): String {
         val normalized = RimeInputNormalizer.normalize(input)
         if (!isReady || normalized.isBlank()) return ""
-        return synchronized(lock) {
+        val allowPersonalization = PersonalizationPolicy.allow(
+            (context as? InputMethodService)?.currentInputEditorInfo,
+        )
+        val committed = synchronized(lock) {
             runCatching {
                 if (!syncSchemaFromSettingsLocked()) return@runCatching ""
                 val snapshot = RimeNative.nativeSetInput(normalized)
@@ -212,6 +220,10 @@ class RimeEngine(private val context: Context) {
                 if (entry != null) RimeNative.nativeSelectCandidate(entry.nativeIndex) else ""
             }.getOrDefault("")
         }
+        if (allowPersonalization && committed.isNotBlank()) {
+            PersonalizationRepository.record(committed)
+        }
+        return committed
     }
 
     /**
@@ -222,20 +234,24 @@ class RimeEngine(private val context: Context) {
     fun selectCandidate(input: String, nativeIndex: Int): String {
         val normalized = RimeInputNormalizer.normalize(input)
         if (!isReady || normalized.isBlank() || nativeIndex < 0) return ""
+        val allowPersonalization = PersonalizationPolicy.allow(
+            (context as? InputMethodService)?.currentInputEditorInfo,
+        )
         mutationQueue.submit {
-            if (isReady) {
-                synchronized(lock) {
-                    if (isReady) {
-                        runCatching {
-                            // nativeIndex belongs to the schema that produced the
-                            // rendered snapshot. Do not switch schemas between
-                            // rendering and consuming that index; the next native
-                            // candidate query will synchronize a changed setting.
-                            RimeNative.nativeSetInput(normalized)
-                            RimeNative.nativeSelectCandidate(nativeIndex)
-                        }
-                    }
-                }
+            if (!isReady) return@submit
+            val committed = synchronized(lock) {
+                if (!isReady) return@synchronized ""
+                runCatching {
+                    // nativeIndex belongs to the schema that produced the
+                    // rendered snapshot. Do not switch schemas between
+                    // rendering and consuming that index; the next native
+                    // candidate query will synchronize a changed setting.
+                    RimeNative.nativeSetInput(normalized)
+                    RimeNative.nativeSelectCandidate(nativeIndex)
+                }.getOrDefault("")
+            }
+            if (allowPersonalization && committed.isNotBlank()) {
+                PersonalizationRepository.record(committed)
             }
         }
         return ""

--- a/app/src/main/java/llc/slacker/openime/VoiceHotwordProvider.kt
+++ b/app/src/main/java/llc/slacker/openime/VoiceHotwordProvider.kt
@@ -6,7 +6,8 @@ object VoiceHotwordProvider {
     private const val MAX_CODE_POINTS = 16
 
     fun current(): String = encode(
-        UserPhraseRepository.voiceHotwords(limit = MAX_HOTWORDS) +
+        PersonalizationRepository.hotwords(limit = MAX_HOTWORDS) +
+            UserPhraseRepository.voiceHotwords(limit = MAX_HOTWORDS) +
             VoiceCorrectionRepository.hotwords(limit = 32),
     )
 

--- a/app/src/test/java/llc/slacker/openime/PersonalizationPolicyTest.kt
+++ b/app/src/test/java/llc/slacker/openime/PersonalizationPolicyTest.kt
@@ -1,0 +1,33 @@
+package llc.slacker.openime
+
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PersonalizationPolicyTest {
+    @Test
+    fun ordinaryTextAllowsPersonalization() {
+        val info = EditorInfo().apply { inputType = InputType.TYPE_CLASS_TEXT }
+        assertTrue(PersonalizationPolicy.allow(info))
+    }
+
+    @Test
+    fun explicitNoPersonalizedLearningFlagBlocksRecording() {
+        val info = EditorInfo().apply {
+            inputType = InputType.TYPE_CLASS_TEXT
+            imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+        }
+        assertFalse(PersonalizationPolicy.allow(info))
+    }
+
+    @Test
+    fun passwordsAndMissingEditorInfoBlockRecording() {
+        val password = EditorInfo().apply {
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+        assertFalse(PersonalizationPolicy.allow(password))
+        assertFalse(PersonalizationPolicy.allow(null))
+    }
+}

--- a/app/src/test/java/llc/slacker/openime/PersonalizationRepositoryTest.kt
+++ b/app/src/test/java/llc/slacker/openime/PersonalizationRepositoryTest.kt
@@ -1,0 +1,35 @@
+package llc.slacker.openime
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PersonalizationRepositoryTest {
+    @After
+    fun cleanUp() {
+        PersonalizationRepository.clear()
+        UserPhraseRepository.clear()
+        VoiceCorrectionRepository.clear()
+    }
+
+    @Test
+    fun oneSelectionDoesNotImmediatelyBecomeAHotword() {
+        PersonalizationRepository.clear()
+        PersonalizationRepository.record("澎湃项目")
+        assertTrue(PersonalizationRepository.hotwords().isEmpty())
+    }
+
+    @Test
+    fun repeatedSelectionFeedsVoiceWithoutCreatingCandidateRanking() {
+        PersonalizationRepository.clear()
+        UserPhraseRepository.clear()
+        VoiceCorrectionRepository.clear()
+
+        repeat(2) { PersonalizationRepository.record("澎湃项目") }
+
+        assertEquals(listOf("澎湃项目"), PersonalizationRepository.hotwords())
+        assertTrue(UserPhraseRepository.candidatesFor("pengpai xiangmu").isEmpty())
+        assertTrue(VoiceHotwordProvider.current().contains("澎湃项目 :1.8"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated on-device `PersonalizationRepository` for repeated explicit candidate selections used only by local ASR hotwords
- capture password / `IME_FLAG_NO_PERSONALIZED_LEARNING` privacy policy at the editor event that produces the Rime learning signal
- record only after a native Rime candidate selection succeeds; keep JSON persistence outside the librime lock
- include repeated personalization events in `VoiceHotwordProvider` without feeding them back into candidate ranking
- keep `UserPhraseRepository` restricted to the Rime-unavailable fallback learner

## Validation
- add policy coverage for normal text, password fields, missing editor info, and `IME_FLAG_NO_PERSONALIZED_LEARNING`
- add repository coverage proving one selection is not promoted, repeated selections become voice hotwords, and the store does not create fallback candidate ranking

Closes #23