### PR TITLE
Fix Chinese nine-key mapping and preview stability

### DIFF
--- a/app/src/androidTest/java/llc/slacker/openime/NineKeyChineseInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/NineKeyChineseInstrumentedTest.kt
@@ -56,7 +56,7 @@ class NineKeyChineseInstrumentedTest {
                 val mode = root.findViewWithTag<View>("key:mode") ?: return@awaitMain null
                 if (!mode.isShown) return@awaitMain null
                 mode.performClick()
-                true
+                mode
             }
         }
         harness.awaitMain { activity ->
@@ -72,7 +72,7 @@ class NineKeyChineseInstrumentedTest {
                 val key = root.findViewWithTag<View>("key-9:$digit") ?: return@awaitMain null
                 if (!key.isShown) return@awaitMain null
                 key.performClick()
-                true
+                key
             }
         }
     }

--- a/app/src/androidTest/java/llc/slacker/openime/NineKeyChineseInstrumentedTest.kt
+++ b/app/src/androidTest/java/llc/slacker/openime/NineKeyChineseInstrumentedTest.kt
@@ -1,0 +1,107 @@
+package llc.slacker.openime
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NineKeyChineseInstrumentedTest {
+
+    private lateinit var harness: DirectActivityHarness<DebugKeyboardActivity>
+
+    @Before
+    fun launch() {
+        harness = DirectActivityHarness(DebugKeyboardActivity::class.java)
+        harness.launch()
+        enterChineseNineKey()
+    }
+
+    @After
+    fun close() {
+        harness.close()
+    }
+
+    @Test
+    fun niHaoSequenceKeepsStablePreedit() {
+        tapDigits("64")
+        assertComposition("ni")
+
+        tapDigits("426")
+        assertComposition("nihao")
+    }
+
+    @Test
+    fun haoDoesNotResolveAsGong() {
+        tapDigits("426")
+        assertComposition("hao")
+        assertStatusDoesNotContain("gong")
+    }
+
+    @Test
+    fun correctedCommonMappingsReachTheRenderer() {
+        tapDigits("943")
+        assertComposition("zhe")
+    }
+
+    private fun enterChineseNineKey() {
+        repeat(2) {
+            harness.awaitMain { activity ->
+                val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
+                val mode = root.findViewWithTag<View>("key:mode") ?: return@awaitMain null
+                if (!mode.isShown) return@awaitMain null
+                mode.performClick()
+                true
+            }
+        }
+        harness.awaitMain { activity ->
+            val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
+            root.findViewWithTag<View>("key-9:2")?.takeIf { it.isShown }
+        }
+    }
+
+    private fun tapDigits(digits: String) {
+        digits.forEach { digit ->
+            harness.awaitMain { activity ->
+                val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return@awaitMain null
+                val key = root.findViewWithTag<View>("key-9:$digit") ?: return@awaitMain null
+                if (!key.isShown) return@awaitMain null
+                key.performClick()
+                true
+            }
+        }
+    }
+
+    private fun assertComposition(expected: String) {
+        val status = harness.awaitMain { activity ->
+            currentStatus(activity).takeIf { it.startsWith("composition=$expected ") }
+        }
+        assertTrue("expected composition=$expected, got $status", status.startsWith("composition=$expected "))
+    }
+
+    private fun assertStatusDoesNotContain(unexpected: String) {
+        val status = harness.awaitMain { activity -> currentStatus(activity).takeIf { it.startsWith("composition=") } }
+        assertTrue("unexpected $unexpected in $status", !status.contains(unexpected))
+    }
+
+    private fun currentStatus(activity: DebugKeyboardActivity): String {
+        val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return ""
+        var status = ""
+        fun walk(view: View) {
+            if (view is TextView) {
+                val text = view.text.toString()
+                if (text.startsWith("composition=")) status = text
+            }
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) walk(view.getChildAt(index))
+            }
+        }
+        walk(root)
+        return status
+    }
+}

--- a/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/CandidateEngine.kt
@@ -342,17 +342,21 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         val pinyins = linkedSetOf<String>()
         val candidates = linkedSetOf<String>()
 
-        fun addEntry(entry: NineKeyEntry, resolvePinyin: Boolean) {
-            pinyins.add(entry.pinyin)
+        fun addEntry(
+            entry: NineKeyEntry,
+            resolvePinyin: Boolean,
+            exposePinyin: Boolean = true,
+        ) {
+            if (exposePinyin) pinyins.add(entry.pinyin)
             candidates.addAll(entry.candidates)
             if (resolvePinyin && entry.pinyin.length <= MAX_LOCAL_RESOLVE_LENGTH) {
                 candidates.addAll(getCandidates(entry.pinyin))
             }
         }
 
-        // Keep the hand-written high-confidence mappings first, then enrich
-        // them with the complete embedded dictionary below.
-        ImeData.keypad9Combinations[digits].orEmpty().forEach { pinyin ->
+        // Legacy hand-written mappings are only hints. Never allow a dirty
+        // digit -> Pinyin entry to outrank the generated dictionary index.
+        highConfidenceNineKeyPinyins(digits).forEach { pinyin ->
             pinyins.add(pinyin)
             candidates.addAll(getCandidates(pinyin))
         }
@@ -374,23 +378,34 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
             }
         }
 
-        // While the current key stream is only a prefix, expose likely full
-        // Pinyin entries so the candidate strip remains useful immediately.
+        // Prefix matches may enrich the candidate strip, but they are not a
+        // stable pre-edit path yet. Do not expose a longer phrase as the main
+        // Pinyin preview for a short digit prefix. Prefer the shortest useful
+        // completions so early key presses remain predictable.
         matchingEntries
             .asSequence()
-            .filter { it.digits.startsWith(digits) }
+            .filter { it.digits.length > digits.length && it.digits.startsWith(digits) }
             .sortedWith(
-                compareByDescending<NineKeyEntry> { it.phrase }
-                    .thenByDescending { it.digits.length },
+                compareBy<NineKeyEntry> { it.digits.length }
+                    .thenByDescending { it.phrase }
+                    .thenBy { it.pinyin },
             )
             .take(MAX_NINE_MATCHES)
-            .forEach { addEntry(it, resolvePinyin = false) }
+            .forEach { addEntry(it, resolvePinyin = false, exposePinyin = false) }
 
         return NineKeyResult(
             pinyins = pinyins.take(MAX_NINE_MATCHES),
             candidates = candidates.filter { it.isNotEmpty() }.take(96),
         )
     }
+
+    private fun highConfidenceNineKeyPinyins(digits: String): List<String> =
+        (ImeData.keypad9Combinations[digits].orEmpty() + NINE_KEY_CORRECTIONS[digits].orEmpty())
+            .asSequence()
+            .map { it.lowercase() }
+            .filter { pinyin -> nineKeyDigitsForPinyin(pinyin) == digits }
+            .distinct()
+            .toList()
 
     private fun buildNineKeyEntries(): List<NineKeyEntry> {
         val merged = LinkedHashMap<String, MutableList<String>>()
@@ -402,7 +417,7 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         }
         val phraseKeys = ImeData.phraseDict.keys
         return merged.mapNotNull { (pinyin, values) ->
-            val digits = pinyinToNineDigits(pinyin) ?: return@mapNotNull null
+            val digits = nineKeyDigitsForPinyin(pinyin) ?: return@mapNotNull null
             NineKeyEntry(
                 pinyin = pinyin,
                 digits = digits,
@@ -414,25 +429,6 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
                 .thenByDescending { it.digits.length }
                 .thenBy { it.pinyin },
         )
-    }
-
-    private fun pinyinToNineDigits(pinyin: String): String? {
-        val digits = StringBuilder(pinyin.length)
-        pinyin.lowercase().forEach { ch ->
-            val digit = when (ch) {
-                in 'a'..'c' -> '2'
-                in 'd'..'f' -> '3'
-                in 'g'..'i' -> '4'
-                in 'j'..'l' -> '5'
-                in 'm'..'o' -> '6'
-                in 'p'..'s' -> '7'
-                in 't'..'v' -> '8'
-                in 'w'..'z' -> '9'
-                else -> return null
-            }
-            digits.append(digit)
-        }
-        return digits.toString().ifEmpty { null }
     }
 
     private fun decodeNineKey(digits: String): NineKeyDecode? {
@@ -497,6 +493,37 @@ class CandidateEngine(externalPinyin: Map<String, List<String>> = emptyMap()) {
         const val MAX_NINE_KEY_DIGITS = 64
         private const val MAX_NINE_MATCHES = 12
         private const val MAX_LOCAL_RESOLVE_LENGTH = 32
+
+        /**
+         * Correct common legacy table mistakes without trusting the table at
+         * runtime. Every value still passes nineKeyDigitsForPinyin() before it
+         * can influence ranking.
+         */
+        private val NINE_KEY_CORRECTIONS = mapOf(
+            "4664" to listOf("gong"),
+            "943" to listOf("zhe"),
+            "94264" to listOf("xiang"),
+            "934946" to listOf("weixin"),
+        )
+
+        fun nineKeyDigitsForPinyin(pinyin: String): String? {
+            val digits = StringBuilder(pinyin.length)
+            pinyin.lowercase().forEach { ch ->
+                val digit = when (ch) {
+                    in 'a'..'c' -> '2'
+                    in 'd'..'f' -> '3'
+                    in 'g'..'i' -> '4'
+                    in 'j'..'l' -> '5'
+                    in 'm'..'o' -> '6'
+                    in 'p'..'s' -> '7'
+                    in 't'..'v' -> '8'
+                    in 'w'..'z' -> '9'
+                    else -> return null
+                }
+                digits.append(digit)
+            }
+            return digits.toString().ifEmpty { null }
+        }
     }
 }
 

--- a/app/src/test/java/llc/slacker/openime/NineKeyChineseTest.kt
+++ b/app/src/test/java/llc/slacker/openime/NineKeyChineseTest.kt
@@ -1,0 +1,82 @@
+package llc.slacker.openime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NineKeyChineseTest {
+    private val engine = CandidateEngine()
+    private val pipeline = CandidatePipeline(engine)
+
+    @Test
+    fun dirtyLegacyMappingsCannotCrossDigitCodes() {
+        val hao = engine.get9KeyCandidates("426")
+        assertEquals("hao", hao.pinyins.first())
+        assertFalse("gong must not leak into 426", "gong" in hao.pinyins)
+
+        val zhi = engine.get9KeyCandidates("944")
+        assertFalse("zhe must not leak into 944", "zhe" in zhi.pinyins)
+
+        val xian = engine.get9KeyCandidates("9426")
+        assertFalse("xiang must not leak into 9426", "xiang" in xian.pinyins)
+    }
+
+    @Test
+    fun returnedPreviewPathsAlwaysEncodeToTheTypedDigits() {
+        listOf("2", "4", "42", "64", "426", "943", "944", "9426", "94264", "64426").forEach { digits ->
+            val result = engine.get9KeyCandidates(digits)
+            assertTrue(
+                "all exposed pinyin paths must exactly encode $digits: ${result.pinyins}",
+                result.pinyins.all { pinyin ->
+                    CandidateEngine.nineKeyDigitsForPinyin(pinyin) == digits
+                },
+            )
+        }
+    }
+
+    @Test
+    fun commonChineseSequencesResolveToStableExpectedPreview() {
+        assertEquals("ni", resolve("64").preview)
+        assertEquals("hao", resolve("426").preview)
+        assertEquals("nihao", resolve("64426").preview)
+        assertEquals("zhe", resolve("943").preview)
+        assertEquals("xiang", resolve("94264").preview)
+        assertEquals("weixin", resolve("934946").preview)
+    }
+
+    @Test
+    fun shortPrefixDoesNotExposeLongPredictionAsPreedit() {
+        listOf("2", "3", "4", "7", "9", "94").forEach { digits ->
+            val resolution = resolve(digits)
+            val previewDigits = CandidateEngine.nineKeyDigitsForPinyin(resolution.preview)
+            if (previewDigits != null) {
+                assertEquals(
+                    "preview must represent only the keys already typed",
+                    digits,
+                    previewDigits,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun commonSequencesStillProduceChineseCandidates() {
+        listOf("64", "426", "64426", "943", "94264").forEach { digits ->
+            val resolution = resolve(digits)
+            assertTrue("$digits should have candidates", resolution.candidates.isNotEmpty())
+            assertTrue(
+                "$digits candidates should not contain raw digits",
+                resolution.candidates.none { candidate -> candidate.any(Char::isDigit) },
+            )
+        }
+    }
+
+    private fun resolve(digits: String): CandidatePipeline.NineKeyResolution =
+        pipeline.resolveNineKey(
+            digits = digits,
+            segmentPrefix = "",
+            preferredSuffix = null,
+            fuzzy = false,
+        )
+}


### PR DESCRIPTION
Closes #81

## What changed
- Reject legacy 9-key digit→Pinyin hints unless the Pinyin encodes exactly to the typed digits.
- Add corrected high-confidence mappings for common broken cases (`gong`, `zhe`, `xiang`, `weixin`) while still validating them through the same encoder.
- Stop longer prefix phrases from becoming the visible Pinyin pre-edit path.
- Prefer shortest prefix completions only for candidate enrichment; exact paths remain authoritative for preview.
- Add regression coverage for `64 -> ni`, `426 -> hao`, `64426 -> nihao`, `943 -> zhe`, `94264 -> xiang`, `934946 -> weixin`, and the invariant that every exposed Pinyin path exactly matches the typed digits.

## Scope
This intentionally stays inside CandidateEngine + unit regressions so 26-key, Service ownership, and renderer behavior are not changed in the P0 fix.