### PR TITLE
Fix association-tap, password loss, JNI nulls, and trim typing/UI hot paths

### DIFF
--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardView.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.BitmapFactory
 import android.graphics.drawable.GradientDrawable
@@ -15,6 +16,7 @@ import android.text.InputType
 import android.text.TextUtils
 import android.text.TextWatcher
 import android.util.Log
+import android.util.LruCache
 import android.view.Gravity
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
@@ -79,6 +81,16 @@ open class ImeKeyboardView(
             onCompositionChanged(composition, candidates)
         }
         fun onCandidateSelected(candidate: String)
+
+        /**
+         * An association ("联想") chip is rendered only *after* a candidate was
+         * committed, i.e. when the composition is already empty. Routing those
+         * clicks through [onCandidateSelected] is therefore always a no-op:
+         * that path guards on a non-empty composition. Associations need their
+         * own commit funnel that does not depend on a live composition.
+         */
+        fun onAssociationSelected(text: String) = Unit
+
         fun onCompositionBackspace()
         fun onThemeChanged(theme: ImeTheme)
         fun onAppearanceChanged(appearance: ImeAppearance)
@@ -98,6 +110,30 @@ open class ImeKeyboardView(
     /** Visual class marker for the gray side/action column in nine-key layouts. */
     private val MARK_SIDE_KEY = 0x1F000002
     private val MARK_FUNCTION_KEY = 0x1F000003
+    /** Cached "is this label a function key" decision, stored per key view. */
+    private val MARK_FUNC_LABEL = 0x1F000011
+    private val MARK_FUNC_LABEL_VALUE = 0x1F000012
+
+    companion object {
+        /** Compiled once. [applyThemeRecursive] walks ~150 nodes per pass. */
+        private val DIGITS_ONLY = Regex("[0-9]+")
+
+        /**
+         * Emoji cells used to decode their PNG from assets inline on the UI
+         * thread: 23-40 synchronous decodes every time the panel opened or
+         * switched category, with no reuse and no recycling. Cache by asset
+         * path so the cost is paid once per process, not once per render.
+         */
+        private const val EMOJI_CACHE_BYTES = 4 * 1024 * 1024
+        private val emojiBitmaps = object : LruCache<String, Bitmap>(EMOJI_CACHE_BYTES) {
+            override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount
+        }
+
+        private fun emojiBitmap(context: Context, assetPath: String): Bitmap? =
+            emojiBitmaps.get(assetPath) ?: runCatching {
+                context.assets.open(assetPath).use { BitmapFactory.decodeStream(it) }
+            }.getOrNull()?.also { emojiBitmaps.put(assetPath, it) }
+    }
 
     private val repeatHandler = Handler(Looper.getMainLooper())
     private val repeatAction = object : Runnable {
@@ -682,7 +718,7 @@ open class ImeKeyboardView(
                     tag = "association-candidate"
                     isClickable = true
                     setPadding(dp(8), 0, dp(8), 0)
-                    setOnClickListener { listener.onCandidateSelected(candidate) }
+                    setOnClickListener { listener.onAssociationSelected(candidate) }
                 },
                 LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.WRAP_CONTENT,
@@ -721,9 +757,37 @@ open class ImeKeyboardView(
         fuzzyEnabled = fuzzy
     }
 
+    /**
+     * Shift state is owned by this view, and nothing else could reset it. A
+     * Caps Lock engaged in one app therefore survived into the next editor,
+     * including password and banking fields. Called from onStartInput.
+     */
+    fun setShiftState(next: ShiftState) {
+        if (shiftState == next) return
+        shiftState = next
+        listener.onShiftStateChanged(next)
+    }
+
     fun shutdown() {
         stopVoiceIfActive()
-        repeatHandler.removeCallbacks(repeatAction)
+        // Drop every pending callback, not just the repeat one. A surviving
+        // backspace/voice runnable fires after the editor changed and would
+        // delete or compose into whichever InputConnection is current then.
+        repeatHandler.removeCallbacksAndMessages(null)
+        removeCallbacks(null)
+        backspaceRepeatStartAction?.let { repeatHandler.removeCallbacks(it) }
+        backspaceRepeatStartAction = null
+        backspaceGestureActive = false
+        backspaceClearArmed = false
+        backspaceRepeatStarted = false
+        backspaceAnchor?.isPressed = false
+        backspaceAnchor = null
+        backspaceClearUiAction = null
+        spaceVoiceGestureActive = false
+        spaceVoiceGestureCancel = false
+        voiceInlineActive = false
+        voiceInlineCancel = false
+        hidePopup()
     }
 
     internal fun isVoiceActive(): Boolean = voiceActive
@@ -2323,9 +2387,7 @@ open class ImeKeyboardView(
         val assetPath = FluentEmojiAssetRepository.pathFor(context, emoji)
         val view = if (assetPath != null) {
             ImageView(context).apply {
-                val bitmap = runCatching {
-                    context.assets.open(assetPath).use { BitmapFactory.decodeStream(it) }
-                }.getOrNull()
+                val bitmap = emojiBitmap(context, assetPath)
                 if (bitmap != null) setImageBitmap(bitmap)
                 scaleType = ImageView.ScaleType.FIT_CENTER
             }
@@ -3082,7 +3144,11 @@ open class ImeKeyboardView(
         val end = composition.selectionEnd.coerceIn(start, current.length)
         val deleteStart = if (start == end) {
             if (start == 0) return true
-            start - 1
+            // Step back by one full Unicode code point, not by one UTF-16 unit.
+            // Otherwise a backspace on an emoji / extension-B Han character
+            // leaves an orphaned high surrogate behind and every later
+            // candidate for this composition is computed from broken text.
+            Character.offsetByCodePoints(current, start, -1).coerceAtLeast(0)
         } else {
             start
         }
@@ -3496,13 +3562,13 @@ open class ImeKeyboardView(
             is ImeKeyView -> {
                 val side = view.getTag(MARK_SIDE_KEY) == true ||
                     (view.parent as? View)?.tag in setOf("pinyin9-actions", "t9-actions", "digits-actions")
-                val function = view.getTag(MARK_FUNCTION_KEY) == true ||
-                    labelIsFunc(view.contentDescription?.toString().orEmpty())
+                val label = view.contentDescription?.toString().orEmpty()
+                val function = view.getTag(MARK_FUNCTION_KEY) == true || view.isFunctionKey(label)
                 // Numeric glyphs are white grid keys only when they are real
                 // number keys. Function labels such as 123 must stay gray.
                 val white = !side && (
                     view.getTag(MARK_WHITE_KEY) == true ||
-                        (!function && view.contentDescription?.toString()?.matches(Regex("[0-9]+")) == true)
+                        (!function && DIGITS_ONLY.matches(label))
                     )
                 val primary = !side && (view.tag == "tab-active" ||
                     view.tag == "key-shift-caps" ||
@@ -3649,8 +3715,18 @@ open class ImeKeyboardView(
         }
     }
 
-    private fun ImeKeyView.mainIsFunc(): Boolean {
-        return labelIsFunc(contentDescription?.toString().orEmpty())
+    /**
+     * [labelIsFunc] runs ~45 substring scans. It used to execute twice per key
+     * on every theme pass, and a theme pass happens on every key tap in the
+     * 26-key layout. Memoize the decision on the view, keyed by the label that
+     * produced it, so a re-labelled key still recomputes correctly.
+     */
+    private fun ImeKeyView.isFunctionKey(label: String): Boolean {
+        if (getTag(MARK_FUNC_LABEL) == label) return getTag(MARK_FUNC_LABEL_VALUE) == true
+        val value = labelIsFunc(label)
+        setTag(MARK_FUNC_LABEL, label)
+        setTag(MARK_FUNC_LABEL_VALUE, value)
+        return value
     }
 
     private fun labelIsFunc(text: String): Boolean =

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -378,7 +378,7 @@ class ImeKeyboardViewV2 private constructor(
          * live. They must not be funnelled through [onCandidateSelected], which
          * is guarded on an active composition and silently drops them.
          */
-        fun onAssociationSelected(text: String)
+        fun onAssociationSelected(text: String) = Unit
 
         fun onCompositionBackspace()
         fun onThemeChanged(theme: ImeTheme)

--- a/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeKeyboardViewV2.kt
@@ -30,8 +30,25 @@ class ImeKeyboardViewV2 private constructor(
 
     private var navigationBottomInsetPx = 0
 
+    /**
+     * [syncProductionKeyPresentation] walks the whole key tree three times
+     * (space geometry, Enter label, handwriting capability). onMeasure fires on
+     * every key tap, every async candidate callback, every insets change and
+     * every rotation, so the previous unconditional call made ~450 node visits
+     * per keystroke. Geometry only depends on the editor's IME options and on
+     * explicit invalidate calls; gate on those.
+     */
+    private var presentationDirty = true
+    private var lastSyncedImeOptions: Int? = null
+
+    /** Force the next measure pass to resynchronize key presentation. */
+    fun invalidatePresentation() {
+        presentationDirty = true
+    }
+
     init {
         adapter.afterModeChanged = {
+            presentationDirty = true
             post { syncProductionKeyPresentation() }
         }
         adapter.afterPanelChanged = { panel ->
@@ -83,8 +100,14 @@ class ImeKeyboardViewV2 private constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        presentationDirty = true
         requestApplyInsets()
         post { syncProductionKeyPresentation() }
+    }
+
+    override fun onDetachedFromWindow() {
+        adapter.shutdown()
+        super.onDetachedFromWindow()
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -109,6 +132,10 @@ class ImeKeyboardViewV2 private constructor(
     }
 
     private fun syncProductionKeyPresentation() {
+        val imeOptions = (context as? InputMethodService)?.currentInputEditorInfo?.imeOptions
+        if (!presentationDirty && imeOptions == lastSyncedImeOptions) return
+        presentationDirty = false
+        lastSyncedImeOptions = imeOptions
         normalizeSpaceRowGeometry()
         syncEnterKeyPresentation()
         syncHandwritingCapability()
@@ -345,6 +372,14 @@ class ImeKeyboardViewV2 private constructor(
             onCompositionChanged(composition, candidates)
         }
         fun onCandidateSelected(candidate: String)
+
+        /**
+         * Association chips are shown after a commit, when no composition is
+         * live. They must not be funnelled through [onCandidateSelected], which
+         * is guarded on an active composition and silently drops them.
+         */
+        fun onAssociationSelected(text: String)
+
         fun onCompositionBackspace()
         fun onThemeChanged(theme: ImeTheme)
         fun onAppearanceChanged(appearance: ImeAppearance)
@@ -442,6 +477,7 @@ class ImeKeyboardViewV2 private constructor(
             candidates: List<String>,
         ) = delegate.onNineKeyCompositionChanged(composition, digitBuffer, pinyinPaths, candidates)
         override fun onCandidateSelected(candidate: String) = delegate.onCandidateSelected(candidate)
+        override fun onAssociationSelected(text: String) = delegate.onAssociationSelected(text)
         override fun onCompositionBackspace() = delegate.onCompositionBackspace()
         override fun onThemeChanged(theme: ImeTheme) = delegate.onThemeChanged(theme)
         override fun onAppearanceChanged(appearance: ImeAppearance) = delegate.onAppearanceChanged(appearance)
@@ -454,5 +490,18 @@ class ImeKeyboardViewV2 private constructor(
         override fun onHapticChanged(enabled: Boolean) = delegate.onHapticChanged(enabled)
         override fun onPopupChanged(enabled: Boolean) = delegate.onPopupChanged(enabled)
         override fun onFuzzyChanged(enabled: Boolean) = delegate.onFuzzyChanged(enabled)
+
+        /**
+         * A pending voice-start runnable survives for the long-press delay. If
+         * the editor goes away first it would still fire and begin recording,
+         * writing partial recognition into whichever InputConnection became
+         * current in the meantime.
+         */
+        fun shutdown() {
+            pendingVoiceStart?.let { voiceHandler.removeCallbacks(it) }
+            pendingVoiceStart = null
+            voiceStartForwarded = false
+            releaseWasCancel = false
+        }
     }
 }

--- a/app/src/main/java/llc/slacker/openime/ImeSettingsRepository.kt
+++ b/app/src/main/java/llc/slacker/openime/ImeSettingsRepository.kt
@@ -17,11 +17,23 @@ object ImeSettingsRepository {
     private const val KEY_SKIN_FONT = "skin_font"
     private const val KEY_SKIN_COLOR = "skin_color"
 
-    fun loadTheme(context: Context): ImeTheme = ImeTheme.IOS
+    /**
+     * Every ImeTheme ships a complete token set in ImeDesignTokens, but the
+     * getter used to hard-code IOS, which made four finished skins unreachable
+     * and made a persisted choice impossible to restore.
+     */
+    fun loadTheme(context: Context): ImeTheme =
+        runCatching {
+            ImeTheme.valueOf(
+                context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                    .getString(KEY_THEME, ImeTheme.IOS.name)
+                    ?: ImeTheme.IOS.name,
+            )
+        }.getOrDefault(ImeTheme.IOS)
 
     fun saveTheme(context: Context, theme: ImeTheme) {
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(KEY_THEME, ImeTheme.IOS.name).apply()
+            .edit().putString(KEY_THEME, theme.name).apply()
     }
 
     fun loadAppearance(context: Context): ImeAppearance =

--- a/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
+++ b/app/src/main/java/llc/slacker/openime/LocalVoiceImeService.kt
@@ -71,6 +71,15 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
     @Volatile
     private var candidateDiagnostics = CandidateDiagnostics()
 
+    /**
+     * candidate-stats fires from every async librime callback, i.e. once per
+     * key. Logcat is a synchronous binder round-trip; keeping it on in release
+     * costs real input latency and it was never gated.
+     */
+    private val verboseLogging: Boolean by lazy {
+        (applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
+    }
+
     private val legacyAdapter = object : ImeKeyboardView.Listener {
         override fun onModeChanged(mode: KeyboardMode) = this@LocalVoiceImeService.onModeChanged(mode)
         override fun onPanelChanged(panel: Panel) = this@LocalVoiceImeService.onPanelChanged(panel)
@@ -113,6 +122,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         )
         override fun onCandidateSelected(candidate: String) =
             this@LocalVoiceImeService.onCandidateSelected(candidate)
+        override fun onAssociationSelected(text: String) =
+            this@LocalVoiceImeService.onAssociationSelected(text)
         override fun onCompositionBackspace() = this@LocalVoiceImeService.onCompositionBackspace()
         override fun onThemeChanged(theme: ImeTheme) = this@LocalVoiceImeService.onThemeChanged(theme)
         override fun onAppearanceChanged(appearance: ImeAppearance) = this@LocalVoiceImeService.onAppearanceChanged(appearance)
@@ -191,22 +202,38 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         super.onStartInput(attribute, restarting)
         invalidateCandidateQueries()
         val kind = EditorInfoAdapter.kind(attribute)
+        // Android restarts the same field after a rotation, a window resize or
+        // a multi-window transition. Dropping the pre-edit there throws away
+        // what the user was mid-way through typing; only a genuinely new
+        // editor resets the composition.
+        val preserve = restarting && state.composition.isNotEmpty()
+        val nextMode = if (restarting) {
+            state.keyboardMode
+        } else {
+            InputMethodSubtypePolicy.defaultKeyboardMode(kind, currentSystemSubtypeLocale())
+        }
         state = state.copy(
             editorInfo = attribute,
             editorAction = attribute?.imeOptions?.and(EditorInfo.IME_MASK_ACTION)
                 ?: EditorInfo.IME_ACTION_NONE,
             passwordField = EditorInfoAdapter.isPassword(kind),
-            keyboardMode = InputMethodSubtypePolicy.defaultKeyboardMode(
-                kind,
-                currentSystemSubtypeLocale(),
-            ),
+            keyboardMode = nextMode,
             panel = Panel.NONE,
-            composition = "",
-            candidates = emptyList(),
+            composition = if (preserve) state.composition else "",
+            candidates = if (preserve) state.candidates else emptyList(),
+            // Everything below is per-editor contract state. None of it was
+            // reset here before, so a Caps Lock or a nine-key filter picked in
+            // one app leaked into the next editor.
+            shiftState = ShiftState.LOWERCASE,
+            pinyin9Filters = emptyList(),
+            selectedPinyin9Filter = "",
+            expandedCandidates = emptyList(),
+            voiceState = VoiceUiState(),
         )
-        lastComposition = ""
+        if (!preserve) lastComposition = ""
         rime.clear()
         keyboardView?.clearAssociationCandidates()
+        keyboardView?.setShiftState(ShiftState.LOWERCASE)
         keyboardView?.setMode(state.keyboardMode)
         keyboardView?.renderState(state)
     }
@@ -310,6 +337,11 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         mainHandler.removeCallbacksAndMessages(null)
         candidateExecutor.shutdownNow()
         invalidateCandidateQueries()
+        // The keyboard view owns a Handler with pending key-repeat callbacks
+        // and holds this service as its listener. Releasing it here keeps the
+        // view tree (and its Context reference) from outliving the service.
+        keyboardView?.shutdown()
+        keyboardView = null
         if (::rime.isInitialized) rime.shutdown()
         if (::voiceLifecycle.isInitialized) voiceLifecycle.destroy()
         activeInstance = null
@@ -322,14 +354,14 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         command.startsWith("longtap:") ->
             keyboardView?.findTestTarget(command.substringAfter("longtap:"))?.performLongClick() == true
         command.startsWith("type:") -> {
-            command.substringAfter("type:").forEach { ch -> onCharacter(ch.toString()) }
+            typeForTest(command.substringAfter("type:"))
             true
         }
         command.startsWith("type64:") -> runCatching {
-            val text = String(
-                java.util.Base64.getDecoder().decode(command.substringAfter("type64:")),
-            )
-            text.forEach { ch -> onCharacter(ch.toString()) }
+            // UTF-8 explicitly: the platform default is not guaranteed to be
+            // UTF-8, while the other base64 commands in this switch already
+            // decode as UTF-8.
+            typeForTest(decodeBase64Utf8(command.substringAfter("type64:")))
             true
         }.getOrDefault(false)
         command.startsWith("nine-sequence:") -> {
@@ -428,6 +460,23 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         else -> false
     }
 
+    private fun decodeBase64Utf8(payload: String): String =
+        String(java.util.Base64.getDecoder().decode(payload), Charsets.UTF_8)
+
+    /**
+     * Feed text one *code point* per call. Iterating Char-by-Char split every
+     * surrogate pair, so a test could never exercise emoji input through the
+     * same path a user takes.
+     */
+    private fun typeForTest(text: String) {
+        var index = 0
+        while (index < text.length) {
+            val end = Character.offsetByCodePoints(text, index, 1)
+            onCharacter(text.substring(index, end))
+            index = end
+        }
+    }
+
     internal fun currentMode(): KeyboardMode = state.keyboardMode
 
     internal fun isVoiceActive(): Boolean = keyboardView?.isVoiceActive() == true
@@ -444,7 +493,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
     internal fun candidateDiagnosticsForTest(): String = candidateDiagnostics.asLogFields()
 
     override fun onModeChanged(mode: KeyboardMode) {
-        Log.i(TAG, "mode=$mode")
+        if (verboseLogging) Log.i(TAG, "mode=$mode")
         commitPendingComposition()
         finalizeVoiceCorrectionIfNeeded()
         invalidateCandidateQueries()
@@ -699,8 +748,16 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         rimeInputs: List<String>,
     ) {
         if (state.passwordField) {
-            val ch = composition.lastOrNull() ?: return
-            gateway.commitText(ch.toString())
+            // Password fields never receive composing text, so the view's
+            // buffer is the only holder of pending input and renderState()
+            // empties it on every report. The buffer therefore contains
+            // exactly what is new since the last report — which can be more
+            // than one character when the user pastes or edits the pre-edit
+            // field. Taking only the last Char dropped everything before it,
+            // and splitting a surrogate pair produced invalid UTF-16 in the
+            // editor. Commit the whole delta.
+            if (composition.isEmpty()) return
+            gateway.commitText(composition)
             lastComposition = ""
             state = state.copy(composition = "", candidates = emptyList())
             renderedCandidateSnapshot = null
@@ -736,13 +793,30 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
         selectCandidate(candidate)
     }
 
+    /**
+     * Association ("联想") chips are produced only after a commit, so there is
+     * no composition for [selectCandidate] to match against. Commit the word
+     * directly and chain to the next association set so a user can keep
+     * tapping: 你好 -> 呀 -> ！
+     */
+    override fun onAssociationSelected(text: String) {
+        if (state.passwordField || text.isEmpty()) return
+        commitPendingComposition()
+        gateway.commitText(text)
+        gateway.finishComposing()
+        keyboardView?.clearAssociationCandidates()
+        keyboardView?.setAssociationCandidates(candidatePipeline.associationsFor(text))
+    }
+
     override fun onCompositionBackspace() {
         onBackspace()
     }
 
     override fun onThemeChanged(theme: ImeTheme) {
-        state = state.copy(theme = ImeTheme.IOS)
-        ImeSettingsRepository.saveTheme(this, ImeTheme.IOS)
+        // The requested theme used to be discarded here and IOS written back,
+        // so every shipped skin except IOS was dead code.
+        state = state.copy(theme = theme)
+        ImeSettingsRepository.saveTheme(this, theme)
     }
 
     override fun onAppearanceChanged(appearance: ImeAppearance) {
@@ -768,6 +842,8 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
     override fun onFuzzyChanged(enabled: Boolean) {
         state = state.copy(fuzzyPinyinEnabled = enabled)
         ImeSettingsRepository.saveFuzzy(this, enabled)
+        // RimeEngine mirrors this value on the candidate hot path.
+        if (::rime.isInitialized) rime.invalidateSettingsCache()
     }
 
     override fun onSkinChanged(opacity: Int, radius: Int, fontSize: Int, primaryColor: String) {
@@ -962,7 +1038,7 @@ class LocalVoiceImeService : InputMethodService(), ImeKeyboardViewV2.Listener, C
                         else -> "none"
                     },
                 )
-                Log.d(TAG, "candidate-stats ${candidateDiagnostics.asLogFields()}")
+                if (verboseLogging) Log.d(TAG, "candidate-stats ${candidateDiagnostics.asLogFields()}")
                 state = state.copy(candidates = finalCandidates)
                 renderedCandidateSnapshot = CandidateSnapshot.rendered(
                     generation = request,

--- a/app/src/main/java/llc/slacker/openime/RimeEngine.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeEngine.kt
@@ -5,14 +5,15 @@ import android.os.Build
 import android.util.Log
 import java.io.File
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 internal data class RimeCandidateEntry(
     val text: String,
     val nativeIndex: Int,
 )
 
-internal fun rimeProbeHasCandidate(snapshot: Array<String>): Boolean =
-    snapshot.drop(2).any { it.isNotBlank() }
+internal fun rimeProbeHasCandidate(snapshot: Array<String>?): Boolean =
+    snapshot.orEmpty().drop(2).any { !it.isNullOrBlank() }
 
 internal fun rimeDataRevision(versionCode: Long): String = "apk-$versionCode"
 
@@ -172,6 +173,12 @@ class RimeEngine(private val context: Context) {
                     errorMessage = throwable.message ?: throwable.javaClass.simpleName
                     Log.w(TAG, "librime unavailable; keeping Kotlin fallback", throwable)
                 }
+                // An Error (OutOfMemoryError, StackOverflowError) is not made
+                // recoverable by falling back to a second dictionary: the
+                // fallback needs the same memory that is already gone. Record
+                // it, clean up, then let it surface instead of hiding a fatal
+                // condition behind a silent "fallback" state.
+                if (throwable is Error) throw throwable
             }
         }
     }
@@ -209,7 +216,7 @@ class RimeEngine(private val context: Context) {
                 if (!syncSchemaFromSettingsLocked()) return@runCatching ""
                 val snapshot = RimeNative.nativeSetInput(normalized)
                 val entry = snapshotCandidateEntries(snapshot).firstOrNull { it.text == candidate }
-                if (entry != null) RimeNative.nativeSelectCandidate(entry.nativeIndex) else ""
+                if (entry != null) RimeNative.nativeSelectCandidate(entry.nativeIndex).orEmpty() else ""
             }.getOrDefault("")
         }
     }
@@ -248,7 +255,7 @@ class RimeEngine(private val context: Context) {
             runCatching {
                 if (!syncSchemaFromSettingsLocked()) return@runCatching ""
                 RimeNative.nativeSetInput(normalized)
-                RimeNative.nativeCommitFirst()
+                RimeNative.nativeCommitFirst().orEmpty()
             }.getOrDefault("")
         }
     }
@@ -269,12 +276,42 @@ class RimeEngine(private val context: Context) {
         startupGate.destroy()
         isReady = false
         mutationQueue.close()
-        cleanupNative()
+        // shutdownNow() does not wait for the task currently running. If that
+        // task is inside nativeStartup it can re-initialize librime *after*
+        // the cleanup below finalized it, leaving a live session nobody owns
+        // and no way to destroy. Give it a bounded grace period first.
         startupExecutor.shutdownNow()
+        runCatching {
+            if (!startupExecutor.awaitTermination(STARTUP_SHUTDOWN_GRACE_MS, TimeUnit.MILLISECONDS)) {
+                Log.w(TAG, "librime startup did not settle before shutdown")
+            }
+        }
+        cleanupNative()
+    }
+
+    /**
+     * Mirrors the persisted fuzzy setting. [syncSchemaFromSettingsLocked] runs
+     * inside every candidate query, and reading SharedPreferences is a disk
+     * read plus an XML parse — it used to happen once per keystroke even when
+     * the value had not changed in months.
+     */
+    @Volatile
+    private var cachedFuzzyPinyin: Boolean? = null
+
+    /** Drop the cached fuzzy setting so the next query re-reads it. */
+    fun invalidateSettingsCache() {
+        cachedFuzzyPinyin = null
+    }
+
+    private fun fuzzyPinyinEnabled(): Boolean {
+        cachedFuzzyPinyin?.let { return it }
+        val value = ImeSettingsRepository.loadFuzzy(context)
+        cachedFuzzyPinyin = value
+        return value
     }
 
     private fun syncSchemaFromSettingsLocked(): Boolean {
-        val desiredSchemaId = rimeSchemaId(ImeSettingsRepository.loadFuzzy(context))
+        val desiredSchemaId = rimeSchemaId(fuzzyPinyinEnabled())
         if (activeSchemaId == desiredSchemaId) return true
         if (!RimeNative.nativeSelectSchema(desiredSchemaId)) return false
         activeSchemaId = desiredSchemaId
@@ -290,11 +327,19 @@ class RimeEngine(private val context: Context) {
         }
     }
 
-    private fun snapshotCandidateEntries(snapshot: Array<String>): List<RimeCandidateEntry> =
-        snapshot.drop(2)
+    private fun snapshotCandidateEntries(snapshot: Array<String>?): List<RimeCandidateEntry> =
+        snapshot.orEmpty()
+            .drop(2)
             .mapIndexedNotNull { index, text ->
-                text.takeIf { it.isNotBlank() }?.let {
-                    RimeCandidateEntry(text = it, nativeIndex = index)
+                // make_strings() can return null outright, or an array whose
+                // tail slots are still null after an allocation failure. The
+                // old code dereferenced the element unconditionally, threw
+                // NPE, and the surrounding runCatching turned that into a
+                // silent empty candidate list with no diagnostic at all.
+                if (text.isNullOrBlank()) {
+                    null
+                } else {
+                    RimeCandidateEntry(text = text, nativeIndex = index)
                 }
             }
             .distinctBy { it.text }
@@ -349,5 +394,11 @@ class RimeEngine(private val context: Context) {
     private companion object {
         const val TAG = "RimeEngine"
         const val HEALTH_PROBE_INPUT = "ni"
+        /**
+         * Upper bound for waiting on an in-flight startup before tearing down.
+         * Short enough to stay off the IME shutdown path, long enough for the
+         * common case where the worker is between cancellation checks.
+         */
+        const val STARTUP_SHUTDOWN_GRACE_MS = 1_500L
     }
 }

--- a/app/src/main/java/llc/slacker/openime/RimeNative.kt
+++ b/app/src/main/java/llc/slacker/openime/RimeNative.kt
@@ -12,14 +12,22 @@ internal object RimeNative {
     @JvmStatic
     external fun nativeSelectSchema(schemaId: String): Boolean
 
+    /**
+     * Nullable on purpose: the native helper returns nullptr when the String
+     * class lookup or the array allocation fails (OOM, exhausted JNI local ref
+     * table), and it can return a partially filled array whose tail slots are
+     * still null. Declaring these non-nullable made Kotlin insert an intrinsic
+     * null check that turned an allocation failure into an NPE in the middle
+     * of candidate rendering.
+     */
     @JvmStatic
-    external fun nativeSetInput(input: String): Array<String>
+    external fun nativeSetInput(input: String): Array<String>?
 
     @JvmStatic
-    external fun nativeSelectCandidate(index: Int): String
+    external fun nativeSelectCandidate(index: Int): String?
 
     @JvmStatic
-    external fun nativeCommitFirst(): String
+    external fun nativeCommitFirst(): String?
 
     @JvmStatic
     external fun nativeClear()

--- a/app/src/main/java/llc/slacker/openime/UserPhraseRepository.kt
+++ b/app/src/main/java/llc/slacker/openime/UserPhraseRepository.kt
@@ -3,6 +3,8 @@ package llc.slacker.openime
 import android.content.Context
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Small private user dictionary for selected Pinyin candidates. It is kept
@@ -14,6 +16,8 @@ import org.json.JSONObject
 object UserPhraseRepository {
     private const val PREFS = "user_phrases"
     private const val KEY = "entries"
+    private const val MAX_ENTRIES = 2000
+    private const val SAVE_DEBOUNCE_MS = 500L
 
     private data class Entry(
         val code: String,
@@ -25,6 +29,17 @@ object UserPhraseRepository {
     private val lock = Any()
     private var preferences: android.content.SharedPreferences? = null
     private val entries = LinkedHashMap<String, Entry>()
+
+    /**
+     * Persisting used to happen inline on the IME thread: every commit built a
+     * JSONArray over up to 2 000 entries and serialized it to a string before
+     * apply() handed the write off. Coalesce a burst of commits instead, and
+     * do the serialization off the IME thread entirely.
+     */
+    private val saveExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "user-phrase-save").apply { isDaemon = true }
+    }
+    private val saveScheduled = AtomicBoolean(false)
 
     fun configure(context: Context) {
         synchronized(lock) {
@@ -74,7 +89,46 @@ object UserPhraseRepository {
                 current.frequency = (current.frequency + 1).coerceAtMost(1_000_000)
                 current.lastUsed = System.currentTimeMillis()
             }
-            saveLocked()
+            trimLocked()
+            scheduleSaveLocked()
+        }
+    }
+
+    /**
+     * Write any pending learning immediately. Call when an input session ends
+     * so a process kill cannot lose more than the debounce window.
+     */
+    fun flush() {
+        synchronized(lock) {
+            if (preferences == null) return
+            writeLocked()
+        }
+    }
+
+    /**
+     * The map used to grow without bound: saveLocked() persisted only the last
+     * 2 000 entries, so memory and disk silently diverged and a long-lived
+     * process kept every phrase it had ever seen.
+     */
+    private fun trimLocked() {
+        if (entries.size <= MAX_ENTRIES) return
+        val keep = entries.entries
+            .sortedWith(
+                compareByDescending<Map.Entry<String, Entry>> { it.value.lastUsed }
+                    .thenByDescending { it.value.frequency },
+            )
+            .take(MAX_ENTRIES)
+            .mapTo(HashSet()) { it.key }
+        entries.keys.retainAll(keep)
+    }
+
+    private fun scheduleSaveLocked() {
+        if (preferences == null) return
+        if (!saveScheduled.compareAndSet(false, true)) return
+        saveExecutor.execute {
+            runCatching { Thread.sleep(SAVE_DEBOUNCE_MS) }
+            saveScheduled.set(false)
+            synchronized(lock) { writeLocked() }
         }
     }
 
@@ -135,10 +189,10 @@ object UserPhraseRepository {
         }
     }
 
-    private fun saveLocked() {
+    private fun writeLocked() {
         val target = preferences ?: return
         val array = JSONArray()
-        entries.values.toList().takeLast(2_000).forEach { entry ->
+        entries.values.toList().takeLast(MAX_ENTRIES).forEach { entry ->
             array.put(
                 JSONObject()
                     .put("code", entry.code)


### PR DESCRIPTION
## 范围

本 PR 来自对 openIME 的一次完整代码审查，集中修复**核心打字链路**与**输入法交互流畅度**两类问题。改动均为外科式修正，附具体文件/函数依据。无法在本机完整编译（依赖 `vendor/librime/deps` 与 LFS 资源需单独拉取），已对 7 个文件做逐符号静态一致性核验（无未定义引用、无重复 import、调用链闭合）。

## 阻断级 / 核心正确性

- **联想候选点击 100% 无响应**：联想 chip 在提交后（组合已清空）才渲染，而 `onCandidateSelected` 首行守卫要求组合非空，点击被静默吞掉。新增 `onAssociationSelected` 专用通道，点击直接 commit 并串联下一组联想（你好 → 呀 → ！）。
- **密码框丢数据**：`composition.lastOrNull()` 取的是单个 UTF-16 `Char`，多字符粘贴只提交最后一个且可能切断代理对。改为提交整个待提交缓冲区。
- **JNI null 元素静默吞候选**：`make_strings` 可能返回 `nullptr` 或含 null 尾槽的数组，旧代码解引用后 NPE 被 `runCatching{}.getOrDefault(emptyList())` 完全吞没。已将 `RimeNative` 三处 native 声明改为可空，引擎侧显式容忍 null/blank 尾项；致命 `Error` 不再被"降级"掩盖。

## 打字与边界

- **退格按 Unicode 码点回溯**（`Character.offsetByCodePoints`），emoji / Ext-B 汉字不再被切成孤儿高代理项。
- **`restarting=true` 保留组合态**：旋转/窗口缩放/多窗口时 Android 复用同一字段，旧逻辑直接清空用户正在输入的内容；仅在真正的新编辑器上重置组合与每编辑器契约状态（Shift、九键过滤、展开候选、语音），避免 Caps Lock 跨应用泄漏。

## 流畅度 / 零延迟（重点）

- **候选热路径不再每次读 SharedPreferences**：`syncSchemaFromSettingsLocked` 原每按键读一次 fuzzy 设置（磁盘读 + XML 解析）。新增 `cachedFuzzyPinyin` 缓存并在 `onFuzzyChanged` 失效。
- **emoji PNG 解码入 LruCache**（按资源路径缓存），原先每次面板打开/分类切换在主线程同步解码 23–40 张。
- **`syncProductionKeyPresentation` 加脏标记 + imeOptions 比对门控**：原先每次 `onMeasure` 跑约 450 次节点遍历。
- **`[0-9]+` 正则编译一次**放入 companion，原先每按键/每键两次扫描。

## 其他

- **主题/皮肤死代码**：`loadTheme`/`saveTheme` 与 `onThemeChanged` 曾硬编码 IOS，使其余皮肤不可达；现尊重并持久化用户选择。
- **`UserPhraseRepository`**：持久化合并不再主线程同步序列化（改为单后台线程 + 防抖），内存映射按 `MAX_ENTRIES` 裁剪（原先无界增长）。
- **生命周期清理**：service destroy 时 shutdown 键盘视图的 Handler/Runnable 并释放视图引用；`candidate-stats` 日志仅 debuggable 构建输出，移除每按键的 logcat 同步 binder 开销。

## 剩余事项

审查报告中其余条目（含构建/CI、测试缺口、CMake/依赖等）作为后续 backlog 跟踪，本 PR 不一次性涵盖，以免引入未经运行时验证的改动。
